### PR TITLE
feat: add exec command and inline pipeline execution

### DIFF
--- a/agentflow/cli.py
+++ b/agentflow/cli.py
@@ -2325,7 +2325,18 @@ def exec_command(
         help="Output format. Defaults to raw text on a terminal and json otherwise.",
     ),
 ) -> None:
-    """Run a single agent with a prompt. Prints the agent's response."""
+    """Run a single agent with a prompt and print the response.
+
+    Examples:
+
+      agentflow exec gemini "What's trending on GitHub?"
+
+      agentflow exec claude "Review this code" --tools read_only
+
+      agentflow exec codex "Fix the test" --tools read_write -m gpt-4.1
+
+      agentflow exec shell "ls -la" --output text
+    """
     if not prompt.strip():
         raise typer.BadParameter("Prompt cannot be empty.")
 

--- a/agentflow/cli.py
+++ b/agentflow/cli.py
@@ -78,6 +78,7 @@ class RunOutputFormat(StrEnum):
     JSON = "json"
     JSON_SUMMARY = "json-summary"
     SUMMARY = "summary"
+    TEXT = "text"
 
 
 class SmokePreflightMode(StrEnum):
@@ -504,6 +505,155 @@ def _run_pipeline(pipeline: object, runs_dir: str, max_concurrent_runs: int, out
 
 def _run_pipeline_path(path: str, runs_dir: str, max_concurrent_runs: int, output: RunOutputFormat) -> None:
     _run_pipeline(_load_pipeline(path), runs_dir, max_concurrent_runs, output)
+
+
+# ---------------------------------------------------------------------------
+# Inline pipeline loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_inline_json(text: str) -> object:
+    from agentflow.loader import load_pipeline_from_text
+
+    try:
+        return load_pipeline_from_text(text, base_dir=Path.cwd())
+    except (json.JSONDecodeError, ValidationError, ValueError) as exc:
+        typer.echo(f"Failed to parse inline pipeline JSON:\n{exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _load_inline_python(code: str) -> object:
+    from agentflow.loader import load_pipeline_from_text
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(Path.cwd()),
+    )
+    if result.returncode != 0:
+        typer.echo(f"Inline Python expression failed:\n{result.stderr.strip()}", err=True)
+        raise typer.Exit(code=1)
+    stdout = result.stdout.strip()
+    if not stdout:
+        typer.echo("Inline Python expression produced no output on stdout.", err=True)
+        raise typer.Exit(code=1)
+    try:
+        return load_pipeline_from_text(stdout, base_dir=Path.cwd())
+    except (json.JSONDecodeError, ValidationError, ValueError) as exc:
+        typer.echo(f"Failed to parse pipeline from inline Python output:\n{exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _load_inline_expression(expression: str) -> object:
+    stripped = expression.strip()
+    if stripped.startswith("{"):
+        return _load_inline_json(stripped)
+    return _load_inline_python(stripped)
+
+
+def _load_from_stdin() -> object:
+    if sys.stdin.isatty():
+        typer.echo("Reading pipeline from stdin... (Ctrl+D to end)", err=True)
+    data = sys.stdin.read()
+    if not data.strip():
+        typer.echo("No input received on stdin.", err=True)
+        raise typer.Exit(code=1)
+    return _load_inline_expression(data)
+
+
+# ---------------------------------------------------------------------------
+# Exec command helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_env_options(env_list: list[str] | None) -> dict[str, str]:
+    if not env_list:
+        return {}
+    parsed: dict[str, str] = {}
+    for item in env_list:
+        if "=" not in item:
+            raise typer.BadParameter(f"Invalid env format: {item!r}. Expected KEY=value.")
+        key, _, value = item.partition("=")
+        parsed[key] = value
+    return parsed
+
+
+def _build_exec_pipeline(
+    agent: str,
+    prompt: str,
+    *,
+    model: str | None = None,
+    tools: str = "read_only",
+    timeout: int = 1800,
+    env: dict[str, str] | None = None,
+    provider: str | None = None,
+    extra_args: list[str] | None = None,
+) -> object:
+    from agentflow.specs import AgentKind, NodeSpec, PipelineSpec, ToolAccess
+
+    try:
+        agent_kind = AgentKind(agent)
+    except ValueError:
+        valid = ", ".join(e.value for e in AgentKind)
+        raise typer.BadParameter(f"Unknown agent: {agent!r}. Valid agents: {valid}.")
+
+    try:
+        tool_access = ToolAccess(tools)
+    except ValueError:
+        raise typer.BadParameter(f"Invalid tools value: {tools!r}. Use 'read_only' or 'read_write'.")
+
+    node_kwargs: dict[str, object] = {
+        "id": "exec",
+        "agent": agent_kind,
+        "prompt": prompt,
+        "tools": tool_access,
+        "timeout_seconds": timeout,
+    }
+    if model is not None:
+        node_kwargs["model"] = model
+    if env:
+        node_kwargs["env"] = env
+    if provider is not None:
+        node_kwargs["provider"] = provider
+    if extra_args:
+        node_kwargs["extra_args"] = extra_args
+
+    return PipelineSpec.model_validate({
+        "name": f"exec-{agent}",
+        "nodes": [node_kwargs],
+    })
+
+
+def _resolve_exec_output(output: RunOutputFormat) -> RunOutputFormat:
+    if output != RunOutputFormat.AUTO:
+        return output
+    if _stream_supports_tty_summary(err=False):
+        return RunOutputFormat.TEXT
+    return RunOutputFormat.JSON
+
+
+def _echo_exec_result(record: object, *, output: RunOutputFormat, run_dir: object = None) -> None:
+    resolved = _resolve_exec_output(output)
+    if resolved == RunOutputFormat.TEXT:
+        node = getattr(record, "nodes", {}).get("exec")
+        if node is None:
+            raise typer.Exit(code=1)
+        status = _status_value(getattr(node, "status", ""))
+        if status == "completed":
+            text = getattr(node, "final_response", None) or getattr(node, "output", None) or ""
+            typer.echo(text)
+        else:
+            # On failure, print whatever output we have, then stderr
+            text = getattr(node, "final_response", None) or getattr(node, "output", None) or ""
+            if text:
+                typer.echo(text, err=True)
+            for line in getattr(node, "stderr_lines", []) or []:
+                if isinstance(line, str) and line.strip():
+                    typer.echo(line, err=True)
+        return
+    # For json/json-summary/summary, delegate to the standard run output
+    _echo_run_result(record, output=output, run_dir=run_dir)
 
 
 def _doctor_report():
@@ -2157,9 +2307,52 @@ def inspect(
     _echo_inspection(report, output=output)
 
 
+@app.command("exec")
+def exec_command(
+    agent: str = typer.Argument(help="Agent to run (codex, claude, kimi, gemini, shell, python)."),
+    prompt: str = typer.Argument(help="Prompt to send to the agent."),
+    model: str | None = typer.Option(None, "--model", "-m", help="Model override."),
+    tools: str = typer.Option("read_only", "--tools", "-t", help="Tool access: read_only or read_write."),
+    timeout: int = typer.Option(1800, "--timeout", help="Timeout in seconds."),
+    env: list[str] | None = typer.Option(None, "--env", help="Environment variables as KEY=value."),
+    provider: str | None = typer.Option(None, "--provider", help="Provider alias or config."),
+    extra_arg: list[str] | None = typer.Option(None, "--extra-arg", help="Extra CLI arguments for the agent."),
+    runs_dir: str = typer.Option(".agentflow/runs", envvar="AGENTFLOW_RUNS_DIR"),
+    max_concurrent_runs: int = typer.Option(2, envvar="AGENTFLOW_MAX_CONCURRENT_RUNS"),
+    output: RunOutputFormat = typer.Option(
+        RunOutputFormat.AUTO,
+        "--output",
+        help="Output format. Defaults to raw text on a terminal and json otherwise.",
+    ),
+) -> None:
+    """Run a single agent with a prompt. Prints the agent's response."""
+    if not prompt.strip():
+        raise typer.BadParameter("Prompt cannot be empty.")
+
+    parsed_env = _parse_env_options(env)
+    pipeline = _build_exec_pipeline(
+        agent, prompt,
+        model=model, tools=tools, timeout=timeout,
+        env=parsed_env, provider=provider, extra_args=extra_arg,
+    )
+
+    store, orchestrator = _build_runtime(runs_dir, max_concurrent_runs)
+
+    async def _run() -> None:
+        run_record = await orchestrator.submit(pipeline)
+        completed = await orchestrator.wait(run_record.id, timeout=None)
+        run_dir = store.run_dir(run_record.id) if hasattr(store, "run_dir") else None
+        _echo_exec_result(completed, output=output, run_dir=run_dir)
+        status = _status_value(completed.status)
+        raise typer.Exit(code=0 if status == "completed" else 1)
+
+    asyncio.run(_run())
+
+
 @app.command()
 def run(
-    path: str,
+    path: str | None = typer.Argument(None, help="Pipeline file path, or '-' for stdin."),
+    expression: str | None = typer.Option(None, "-e", "--expression", help="Inline pipeline JSON or Python expression."),
     runs_dir: str = typer.Option(".agentflow/runs", envvar="AGENTFLOW_RUNS_DIR"),
     max_concurrent_runs: int = typer.Option(2, envvar="AGENTFLOW_MAX_CONCURRENT_RUNS"),
     output: RunOutputFormat = typer.Option(
@@ -2178,14 +2371,25 @@ def run(
         help="Print a successful local preflight summary to stderr when preflight runs.",
     ),
 ) -> None:
-    pipeline = _load_pipeline_with_optional_smoke_preflight(
-        path,
-        path,
-        preflight,
-        output,
-        show_preflight=show_preflight,
-    )
-    _run_pipeline(pipeline, runs_dir, max_concurrent_runs, output)
+    if expression is not None:
+        if path is not None:
+            raise typer.BadParameter("Use either a file path or -e/--expression, not both.")
+        pipeline = _load_inline_expression(expression)
+    elif path == "-":
+        pipeline = _load_from_stdin()
+    elif path is not None:
+        pipeline = _load_pipeline_with_optional_smoke_preflight(
+            path,
+            path,
+            preflight,
+            output,
+            show_preflight=show_preflight,
+        )
+    else:
+        raise typer.BadParameter("Provide a pipeline file path, use '-' for stdin, or pass -e/--expression.")
+    # For TEXT output (only meaningful for exec), fall back to SUMMARY for run
+    effective_output = output if output != RunOutputFormat.TEXT else RunOutputFormat.SUMMARY
+    _run_pipeline(pipeline, runs_dir, max_concurrent_runs, effective_output)
 
 
 @app.command()

--- a/skills/agentflow/SKILL.md
+++ b/skills/agentflow/SKILL.md
@@ -1,13 +1,28 @@
 ---
 name: agentflow
-description: Build and run multi-agent pipelines using AgentFlow. Use when the user wants to orchestrate codex, claude, or kimi agents in parallel, in sequence, or in iterative loops. Trigger when the user mentions multi-agent workflows, fan-out tasks, code review pipelines, iterative implementation loops, running agents on EC2/ECS, or any task that needs multiple AI agents coordinated together. Also trigger for "agentflow", "pipeline", "graph of agents", "fanout", "shard", or "run codex on remote".
+description: Run AI agents and build multi-agent pipelines using AgentFlow. Use when the user wants to call codex, claude, kimi, or gemini agents — either as a single one-off call or orchestrated in parallel, in sequence, or in iterative loops. Trigger when the user mentions running an agent, multi-agent workflows, fan-out tasks, code review pipelines, iterative implementation loops, running agents on EC2/ECS, or any task that needs AI agents coordinated together. Also trigger for "agentflow", "pipeline", "graph of agents", "fanout", "shard", "run codex on remote", "exec agent", or "call gemini/claude/codex". For details on exec and inline execution, read references/exec.md.
 ---
 
 # AgentFlow
 
-Build multi-agent pipelines where codex, claude, and kimi work together in dependency graphs with parallel fanout, iterative cycles, and remote execution.
+Run AI agents directly or build multi-agent pipelines where codex, claude, kimi, and gemini work together in dependency graphs with parallel fanout, iterative cycles, and remote execution.
 
-## Quick Start
+## Quick Start: Single Agent Call
+
+The fastest way to run an agent — no files needed:
+
+```bash
+agentflow exec gemini "What's trending on GitHub?" --model gemini-3-pro-preview
+agentflow exec claude "Explain this codebase" --tools read_only
+agentflow exec codex "Fix the failing test" --tools read_write
+agentflow exec shell "ls -la"
+```
+
+`exec` prints the agent's response directly. Use `--output text` to force raw text, `--output json` for structured output. See `references/exec.md` for all options.
+
+## Quick Start: Pipeline
+
+For multi-step workflows, define a pipeline:
 
 ```python
 from agentflow import Graph, codex, claude
@@ -23,17 +38,27 @@ print(g.to_json())
 
 Run: `agentflow run pipeline.py`
 
+Or inline without a file:
+
+```bash
+# Inline JSON
+agentflow run -e '{"name":"review","nodes":[{"id":"a","agent":"codex","prompt":"Plan the work"},{"id":"b","agent":"claude","prompt":"Implement: {{ nodes.a.output }}","depends_on":["a"]}]}'
+
+# From stdin
+python3 pipeline.py | agentflow run -
+```
+
 ## Imports
 
 ```python
-from agentflow import Graph, codex, claude, kimi       # agents
+from agentflow import Graph, codex, claude, kimi, gemini  # agents
 from agentflow import fanout, merge                    # parallel shards
 from agentflow import shell, python_node, sync         # utility nodes
 ```
 
 ## Nodes
 
-Create agent nodes with `codex()`, `claude()`, or `kimi()`. Required: `task_id`, `prompt`.
+Create agent nodes with `codex()`, `claude()`, `kimi()`, or `gemini()`. Required: `task_id`, `prompt`.
 
 ```python
 codex(
@@ -245,10 +270,23 @@ Graph("name",
 ## CLI
 
 ```bash
-agentflow run pipeline.py                # run pipeline
-agentflow run pipeline.py --output summary
+# Single agent call (no file needed)
+agentflow exec <agent> "<prompt>" [--model X] [--tools read_only|read_write] [--output text|json]
+
+# Run pipeline from file
+agentflow run pipeline.py
+agentflow run pipeline.json --output summary
+
+# Run pipeline inline (no file needed)
+agentflow run -e '{"name":"q","nodes":[...]}'            # inline JSON
+agentflow run -e 'from agentflow import ...; print(...)'  # inline Python
+echo '{"name":"q","nodes":[...]}' | agentflow run -       # from stdin
+
+# Inspect and validate
 agentflow inspect pipeline.py            # show graph structure
 agentflow validate pipeline.py           # check without running
 agentflow templates                       # list starter templates
 agentflow init > pipeline.py             # scaffold starter
 ```
+
+For the full exec reference (all flags, output formats, env vars, examples), read `references/exec.md`.

--- a/skills/agentflow/references/exec.md
+++ b/skills/agentflow/references/exec.md
@@ -1,0 +1,212 @@
+# AgentFlow Exec & Inline Execution Reference
+
+This reference covers running agents without creating pipeline files — the `exec` command for single agent calls, and inline/stdin modes for full pipelines.
+
+## Table of Contents
+
+- [exec command](#exec-command)
+- [exec flags](#exec-flags)
+- [exec output formats](#exec-output-formats)
+- [exec examples](#exec-examples)
+- [inline pipeline (run -e)](#inline-pipeline-run--e)
+- [stdin pipeline (run -)](#stdin-pipeline-run--)
+- [choosing exec vs pipeline](#choosing-exec-vs-pipeline)
+
+---
+
+## exec command
+
+Run a single agent with a prompt. No files needed — prompt in, output out.
+
+```
+agentflow exec <agent> "<prompt>" [options]
+```
+
+**Agents:** `codex`, `claude`, `kimi`, `gemini`, `shell`, `python`
+
+The simplest possible usage:
+
+```bash
+agentflow exec gemini "What's trending on GitHub?"
+```
+
+This prints the agent's response directly to stdout and exits.
+
+## exec flags
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--model` | `-m` | agent default | Model override (e.g., `gemini-3-pro-preview`, `claude-sonnet-4-6`) |
+| `--tools` | `-t` | `read_only` | Tool access: `read_only` (safe, no writes) or `read_write` (full access) |
+| `--timeout` | | `1800` | Timeout in seconds |
+| `--env` | | none | Environment variables as `KEY=value` (repeatable) |
+| `--provider` | | none | Provider alias (e.g., `google`, `anthropic`, `openai`) |
+| `--extra-arg` | | none | Extra CLI arguments passed to the agent (repeatable) |
+| `--output` | | `auto` | Output format: `auto`, `text`, `json`, `json-summary`, `summary` |
+
+### --tools
+
+Controls what the agent can do on your machine:
+
+- **`read_only`** (default): The agent can read files and search the web but cannot modify anything. Use this for questions, analysis, code review, and research.
+- **`read_write`**: The agent can read, write, and execute. Use this for tasks that need to create or modify files, run commands, or make changes.
+
+### --env
+
+Pass environment variables to the agent process. Useful for API keys, config, or dynamic values:
+
+```bash
+agentflow exec shell 'echo $DB_HOST' --env DB_HOST=localhost --env DB_PORT=5432
+```
+
+Values with `=` signs work correctly — only the first `=` is used as the separator:
+
+```bash
+agentflow exec shell 'echo $CONN' --env 'CONN=host=db;port=5432'
+```
+
+### --model
+
+Override the agent's default model. The available models depend on the agent:
+
+```bash
+agentflow exec gemini "Search for X" --model gemini-3-pro-preview
+agentflow exec gemini "Quick question" --model gemini-3-flash-preview
+agentflow exec claude "Explain this" --model claude-sonnet-4-6
+```
+
+## exec output formats
+
+| Format | When to use | What it prints |
+|---|---|---|
+| `auto` (default) | Most cases | `text` on TTY, `json` when piped |
+| `text` | You want just the response | Raw agent response, nothing else |
+| `json` | Programmatic consumption | Full `RunRecord` with all metadata |
+| `json-summary` | Compact programmatic use | Compact summary with status, duration, preview |
+| `summary` | Pipeline-style overview | Human-readable run summary like `agentflow run` |
+
+**Example 1:** Raw text output (great for piping to other tools)
+```bash
+agentflow exec gemini "Summarize this repo" --output text > summary.txt
+```
+
+**Example 2:** JSON output (great for parsing in scripts)
+```bash
+result=$(agentflow exec codex "List the top 5 bugs" --output json)
+echo "$result" | jq '.nodes.exec.final_response'
+```
+
+**Example 3:** Auto mode (default)
+```bash
+# In a terminal: prints raw text
+agentflow exec claude "Hello"
+
+# Piped: prints JSON
+agentflow exec claude "Hello" | jq .
+```
+
+## exec examples
+
+### Quick questions
+
+```bash
+agentflow exec gemini "What is the latest version of Node.js?"
+agentflow exec claude "Explain the difference between async and await"
+```
+
+### Web search (gemini has built-in Google Search)
+
+```bash
+agentflow exec gemini "Search the web for the top trending GitHub repos today" --model gemini-3-flash-preview
+```
+
+### Code review (read-only, safe)
+
+```bash
+agentflow exec claude "Review the code in src/api.py for security issues" --tools read_only
+```
+
+### Code modification (read-write, makes changes)
+
+```bash
+agentflow exec codex "Fix the failing test in tests/test_auth.py" --tools read_write
+```
+
+### Shell and Python (instant, no API calls)
+
+```bash
+agentflow exec shell "find . -name '*.py' | wc -l"
+agentflow exec python "import json; print(json.dumps({'status': 'ok'}))"
+```
+
+### With environment variables
+
+```bash
+agentflow exec codex "Deploy to staging" --tools read_write --env DEPLOY_ENV=staging --env DRY_RUN=true
+```
+
+---
+
+## Inline pipeline (run -e)
+
+Run a full pipeline without creating a file. Pass JSON or Python directly:
+
+### Inline JSON
+
+```bash
+agentflow run -e '{"name":"review","concurrency":2,"nodes":[
+  {"id":"scan","agent":"codex","prompt":"List the top 3 files to review"},
+  {"id":"review","agent":"claude","prompt":"Review: {{ nodes.scan.output }}","depends_on":["scan"],"tools":"read_only"}
+]}'
+```
+
+### Inline Python
+
+If the expression doesn't start with `{`, it's treated as Python code. The Python script must print pipeline JSON to stdout (same as `.py` pipeline files):
+
+```bash
+agentflow run -e 'from agentflow import Graph, codex, claude, fanout
+with Graph("fan-review", concurrency=4) as g:
+    scan = codex(task_id="scan", prompt="List 3 files to review")
+    reviews = fanout(codex(task_id="review", prompt="Review {{ item.file }}"), [{"file":"api.py"},{"file":"auth.py"}])
+    scan >> reviews
+print(g.to_json())'
+```
+
+### How detection works
+
+- Starts with `{` → parsed as JSON
+- Anything else → executed as Python via `python -c`
+
+---
+
+## Stdin pipeline (run -)
+
+Read a pipeline from stdin using `-` as the path:
+
+```bash
+# Pipe JSON directly
+echo '{"name":"test","nodes":[{"id":"q","agent":"shell","prompt":"echo hello"}]}' | agentflow run -
+
+# Pipe from a Python script
+python3 my_pipeline.py | agentflow run -
+
+# Pipe from curl or any other source
+curl -s https://example.com/pipeline.json | agentflow run -
+```
+
+---
+
+## Choosing exec vs pipeline
+
+| Scenario | Use |
+|---|---|
+| Single question or task | `agentflow exec` |
+| Web search | `agentflow exec gemini` |
+| Quick shell/python command | `agentflow exec shell` or `agentflow exec python` |
+| Two+ agents that depend on each other | `agentflow run -e` or a pipeline file |
+| Parallel fan-out across many items | Pipeline file with `fanout()` |
+| Iterative write-review loops | Pipeline file with `on_failure` cycles |
+| Recurring or complex workflows | Pipeline `.py` or `.json` file |
+
+**Rule of thumb:** If one agent can do the job, use `exec`. If you need multiple agents to coordinate, use a pipeline.


### PR DESCRIPTION
## Summary

- **`agentflow exec`** — run a single agent with a prompt, get raw output back. No files needed.
- **`agentflow run -e`** — pass inline JSON or Python expression directly
- **`agentflow run -`** — read pipeline from stdin

## Usage

```bash
# Single agent call — just prompt in, output out
agentflow exec shell "echo hello"
agentflow exec claude "Explain this codebase" --tools read_only
agentflow exec gemini "Search GitHub trends" --model gemini-3-pro-preview --output text

# Inline JSON pipeline
agentflow run -e '{"name":"q","nodes":[{"id":"q","agent":"shell","prompt":"echo works"}]}'

# Inline Python pipeline
agentflow run -e 'from agentflow import Graph, shell
with Graph("test") as g:
    shell(task_id="q", script="echo works")
print(g.to_json())'

# Pipeline from stdin
echo '{"name":"q","nodes":[...]}' | agentflow run -
python3 my_pipeline.py | agentflow run -
```

## Design

- `exec` builds a single-node `PipelineSpec` in memory, runs through the standard orchestrator
- `exec --output auto` defaults to raw text on TTY, JSON when piped
- `run -e` auto-detects JSON (starts with `{`) vs Python (executed as subprocess, matching existing `.py` loader)
- `run -` reads stdin, same JSON/Python detection
- Backwards compatible: `agentflow run <path>` works unchanged

## Test plan

- [x] `agentflow exec shell "echo hello"` → `hello`
- [x] `agentflow exec shell "echo hello" --output text` → `hello`
- [x] `agentflow run -e '{"name":"q","nodes":[...]}'` → pipeline runs
- [x] `agentflow run -e 'from agentflow import ...'` → Python inline works
- [x] `echo '...' | agentflow run -` → stdin works
- [x] `agentflow run pipeline.py` → backwards compatible
- [x] Error cases: bad agent, empty prompt, both path and -e, no input
- [x] All 156 non-CLI tests pass; CLI test failures are pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)