### PR TITLE
Add graph-level optimization rounds

### DIFF
--- a/agentflow/dsl.py
+++ b/agentflow/dsl.py
@@ -85,6 +85,8 @@ class Graph:
         *,
         description: str | None = None,
         working_dir: str = ".",
+        optimizer: str | None = None,
+        n_run: int = 1,
         concurrency: int = 4,
         fail_fast: bool = False,
         max_iterations: int = 10,
@@ -97,6 +99,8 @@ class Graph:
         self.name = name
         self.description = description
         self.working_dir = working_dir
+        self.optimizer = optimizer
+        self.n_run = n_run
         self.concurrency = concurrency
         self.fail_fast = fail_fast
         self.max_iterations = max_iterations
@@ -136,6 +140,9 @@ class Graph:
         if self.description is not None:
             payload["description"] = self.description
         payload["working_dir"] = self.working_dir
+        if self.optimizer is not None:
+            payload["optimizer"] = self.optimizer
+        payload["n_run"] = self.n_run
         payload["concurrency"] = self.concurrency
         payload["fail_fast"] = self.fail_fast
         payload["max_iterations"] = self.max_iterations

--- a/agentflow/graph_optimizer.py
+++ b/agentflow/graph_optimizer.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from pprint import pformat
+from typing import Any
+
+from agentflow.specs import PipelineSpec, RunRecord, normalize_agent_name
+from agentflow.store import RunStore
+from agentflow.utils import ensure_dir, json_dumps
+
+
+GENERATED_PIPELINE_FILENAME = "pipeline.py"
+GENERATED_PIPELINE_ORIGINAL_FILENAME = "pipeline.original.py"
+GENERATED_PIPELINE_EDITED_FILENAME = "pipeline.edited.py"
+GRAPH_REPORT_FILENAME = "graph_report.json"
+OPTIMIZER_PROMPT_FILENAME = "optimizer-prompt.txt"
+OPTIMIZER_RESULT_FILENAME = "optimizer-result.json"
+OPTIMIZER_VALIDATION_FILENAME = "optimizer-validation.json"
+GRAPH_OPTIMIZER_MAX_ATTEMPTS = 3
+
+
+def editable_pipeline_payload(pipeline: PipelineSpec) -> dict[str, Any]:
+    payload = pipeline.model_dump(mode="json")
+    payload.pop("optimizer", None)
+    payload.pop("n_run", None)
+    return payload
+
+
+def render_editable_pipeline_python(pipeline: PipelineSpec) -> str:
+    payload = editable_pipeline_payload(pipeline)
+    payload_text = pformat(payload, sort_dicts=False, width=100)
+    return (
+        "from __future__ import annotations\n\n"
+        "import json\n\n"
+        "# This file is generated for graph optimization rounds.\n"
+        "# Edit PIPELINE directly. Reorder nodes by moving entries in PIPELINE['nodes'] and\n"
+        "# updating `depends_on` lists as needed. Keep absolute execution paths unless you\n"
+        "# intentionally want to retarget the graph.\n\n"
+        f"PIPELINE = {payload_text}\n\n"
+        "if __name__ == '__main__':\n"
+        "    print(json.dumps(PIPELINE, ensure_ascii=False, indent=2))\n"
+    )
+
+
+def write_editable_pipeline_python(path: Path, pipeline: PipelineSpec) -> None:
+    ensure_dir(path.parent)
+    path.write_text(render_editable_pipeline_python(pipeline), encoding="utf-8")
+
+
+def copy_run_traces(run: RunRecord, store: RunStore, traces_dir: Path) -> dict[str, str]:
+    copied: dict[str, str] = {}
+    ensure_dir(traces_dir)
+    for node in run.pipeline.nodes:
+        source = store.artifact_path(run.id, node.id, "trace.jsonl")
+        if not source.exists():
+            continue
+        target = traces_dir / f"{node.id}.trace.jsonl"
+        shutil.copy2(source, target)
+        copied[node.id] = str(target)
+    return copied
+
+
+def build_graph_report(
+    *,
+    parent_run_id: str,
+    round_number: int,
+    total_rounds: int,
+    run: RunRecord,
+    store: RunStore,
+    copied_traces: dict[str, str],
+) -> dict[str, Any]:
+    nodes: list[dict[str, Any]] = []
+    pipeline_nodes = run.pipeline.node_map
+    for node_id, result in run.nodes.items():
+        pipeline_node = pipeline_nodes[node_id]
+        nodes.append(
+            {
+                "id": node_id,
+                "agent": normalize_agent_name(pipeline_node.agent),
+                "prompt_template": pipeline_node.prompt,
+                "depends_on": list(pipeline_node.depends_on),
+                "status": result.status.value,
+                "started_at": result.started_at,
+                "finished_at": result.finished_at,
+                "exit_code": result.exit_code,
+                "output": result.output,
+                "final_response": result.final_response,
+                "success": result.success,
+                "success_details": list(result.success_details),
+                "attempt_count": len(result.attempts),
+                "attempts": [attempt.model_dump(mode="json") for attempt in result.attempts],
+                "artifacts": {
+                    "trace_jsonl": copied_traces.get(node_id),
+                    "stdout_log": str(store.artifact_path(run.id, node_id, "stdout.log")),
+                    "stderr_log": str(store.artifact_path(run.id, node_id, "stderr.log")),
+                    "output_txt": str(store.artifact_path(run.id, node_id, "output.txt")),
+                    "result_json": str(store.artifact_path(run.id, node_id, "result.json")),
+                    "launch_json": str(store.artifact_path(run.id, node_id, "launch.json")),
+                },
+            }
+        )
+
+    return {
+        "parent_run_id": parent_run_id,
+        "round_number": round_number,
+        "total_rounds": total_rounds,
+        "child_run_id": run.id,
+        "pipeline": editable_pipeline_payload(run.pipeline),
+        "run": {
+            "id": run.id,
+            "status": run.status.value,
+            "created_at": run.created_at,
+            "started_at": run.started_at,
+            "finished_at": run.finished_at,
+        },
+        "events": [event.model_dump(mode="json") for event in store.get_events(run.id)],
+        "nodes": nodes,
+    }
+
+
+def render_graph_optimizer_prompt(
+    *,
+    optimizer: str,
+    pipeline_path: Path,
+    graph_report_path: Path,
+    traces_dir: Path,
+    round_number: int,
+    total_rounds: int,
+    attempt_number: int = 1,
+    max_attempts: int = GRAPH_OPTIMIZER_MAX_ATTEMPTS,
+    previous_failure: str | None = None,
+) -> str:
+    failure_section = ""
+    if previous_failure:
+        failure_section = (
+            "\nPrevious optimizer/load failure to fix before finishing:\n"
+            f"{previous_failure}\n"
+        )
+
+    return (
+        f"You are optimizing an AgentFlow graph using `{optimizer}`.\n"
+        f"Round: {round_number} of {total_rounds}\n"
+        f"Optimizer attempt: {attempt_number} of {max_attempts}\n"
+        f"Editable pipeline file: {pipeline_path}\n"
+        f"Graph report JSON: {graph_report_path}\n"
+        f"Copied node traces directory: {traces_dir}\n"
+        f"{failure_section}\n"
+        "Goal:\n"
+        "- Improve the next round of graph execution using evidence from the graph report and copied traces.\n"
+        "- Prefer changes that materially improve correctness, reliability, latency, or coordination quality.\n"
+        "- Prefer focused, high-leverage edits over broad churn.\n"
+        "\n"
+        "Working materials:\n"
+        "- `pipeline.py` is the only file you should edit.\n"
+        "- `graph_report.json` contains the current graph, node outcomes, timings, outputs, attempts, events, and artifact paths.\n"
+        "- `traces/` contains per-node trace files copied from the completed round.\n"
+        "\n"
+        "Allowed graph changes:\n"
+        "- Reorder nodes.\n"
+        "- Rewrite node prompts.\n"
+        "- Add, remove, or rewire dependencies.\n"
+        "- Add or remove nodes when justified.\n"
+        "- Modify graph-level settings such as concurrency, fail-fast behavior, or iteration controls.\n"
+        "\n"
+        "Guardrails:\n"
+        "- Edit `pipeline.py` in place.\n"
+        "- Preserve a valid Python script that defines `PIPELINE` and prints it as JSON when executed.\n"
+        "- Keep at least one node in the graph.\n"
+        "- Keep node ids stable unless there is a strong reason to rename, add, or remove them.\n"
+        "- Keep `working_dir` and local target `cwd` paths absolute unless you intentionally want to retarget execution.\n"
+        "- If the previous attempt failed, fix that load or validation error in `pipeline.py` before making further changes.\n"
+        "- Do not run the full graph yourself; the outer harness will validate and run the next round.\n"
+        "\n"
+        "Validation checklist before finishing:\n"
+        "- `pipeline.py` is syntactically valid Python.\n"
+        "- Running `pipeline.py` prints a valid pipeline JSON payload.\n"
+        "- The resulting pipeline validates cleanly and contains at least one node.\n"
+        "- Dependency references are valid after any reorder or rewrite.\n"
+        "- The edited graph still reflects the intended workflow.\n"
+        "- Review carefully for regressions before finishing.\n"
+    )
+
+
+def write_optimizer_result(path: Path, *, command: str, exit_code: int, stdout: str, stderr: str) -> None:
+    ensure_dir(path.parent)
+    path.write_text(
+        json_dumps(
+            {
+                "command": command,
+                "exit_code": exit_code,
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_validation_result(path: Path, *, ok: bool, error: str | None = None) -> None:
+    ensure_dir(path.parent)
+    payload: dict[str, Any] = {"ok": ok}
+    if error is not None:
+        payload["error"] = error
+    path.write_text(json_dumps(payload), encoding="utf-8")

--- a/agentflow/orchestrator.py
+++ b/agentflow/orchestrator.py
@@ -8,17 +8,35 @@ rerun, and periodic-control signals without blocking other runs.
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 import json
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from pydantic import BaseModel, Field, ValidationError
 
 from agentflow.agents.registry import AdapterRegistry, default_adapter_registry
 from agentflow.context import render_node_prompt
+from agentflow.graph_optimizer import (
+    GRAPH_OPTIMIZER_MAX_ATTEMPTS,
+    GENERATED_PIPELINE_EDITED_FILENAME,
+    GENERATED_PIPELINE_FILENAME,
+    GENERATED_PIPELINE_ORIGINAL_FILENAME,
+    GRAPH_REPORT_FILENAME,
+    OPTIMIZER_PROMPT_FILENAME,
+    OPTIMIZER_RESULT_FILENAME,
+    OPTIMIZER_VALIDATION_FILENAME,
+    build_graph_report,
+    copy_run_traces,
+    render_graph_optimizer_prompt,
+    write_editable_pipeline_python,
+    write_optimizer_result,
+    write_validation_result,
+)
+from agentflow.loader import load_pipeline_from_path
 from agentflow.prepared import ExecutionPaths, PreparedExecution, build_execution_paths
 from agentflow.runners.registry import RunnerRegistry, default_runner_registry
 from agentflow.specs import (
@@ -30,12 +48,13 @@ from agentflow.specs import (
     RunEvent,
     RunRecord,
     RunStatus,
+    builtin_agent_kind,
 )
 from agentflow.store import RunStore
 from agentflow.success import evaluate_success
-from agentflow.tuned_agents import resolve_node_for_execution
+from agentflow.tuned_agents import _parse_agent_output, _run_optimizer, resolve_node_for_execution
 from agentflow.traces import create_trace_parser
-from agentflow.utils import looks_sensitive_key, redact_sensitive_shell_value, utcnow_iso
+from agentflow.utils import ensure_dir, looks_sensitive_key, redact_sensitive_shell_value, utcnow_iso
 
 
 _TERMINAL_NODE_STATUSES = {
@@ -165,26 +184,37 @@ class Orchestrator:
                 except KeyError:
                     pass
 
-    async def submit(self, pipeline: PipelineSpec) -> RunRecord:
-        """Create a queued run and start its background scheduler when a slot opens.
+    def _initialize_run_tracking(self, run_id: str, *, cancel_flag: threading.Event | None = None) -> None:
+        self._cancel_flags[run_id] = cancel_flag or threading.Event()
+        self._run_finished[run_id] = threading.Event()
+        self._node_cancel_flags[run_id] = set()
+        self._pending_node_reruns[run_id] = set()
 
-        Returns the newly created `RunRecord` with all nodes initialized as pending.
-        """
-
+    async def _create_queued_run(
+        self,
+        pipeline: PipelineSpec,
+        *,
+        cancel_flag: threading.Event | None = None,
+        optimization_parent_run_id: str | None = None,
+        optimization_round: int | None = None,
+        optimization_session: dict[str, Any] | None = None,
+    ) -> RunRecord:
         run_id = self.store.new_run_id()
+        self._initialize_run_tracking(run_id, cancel_flag=cancel_flag)
         run = RunRecord(
             id=run_id,
             status=RunStatus.QUEUED,
             pipeline=pipeline,
+            optimization_parent_run_id=optimization_parent_run_id,
+            optimization_round=optimization_round,
+            optimization_session=deepcopy(optimization_session),
             nodes={node.id: NodeResult(node_id=node.id, status=NodeStatus.PENDING) for node in pipeline.nodes},
         )
-        self._cancel_flags[run_id] = threading.Event()
-        self._run_finished[run_id] = threading.Event()
-        self._node_cancel_flags[run_id] = set()
-        self._pending_node_reruns[run_id] = set()
         await self.store.create_run(run)
         await self._publish(run_id, "run_queued", pipeline=pipeline.model_dump(mode="json"))
+        return run
 
+    def _start_background(self, run_id: str, entrypoint: Callable[[], Any]) -> None:
         def _background() -> None:
             acquired = False
             try:
@@ -193,13 +223,318 @@ class Orchestrator:
                         asyncio.run(self._finalize_cancelled_queue_run(run_id))
                         return
                     acquired = self._run_slots.acquire(timeout=0.1)
-                asyncio.run(self.run(run_id))
+                asyncio.run(entrypoint())
             finally:
                 if acquired:
                     self._run_slots.release()
                 self._run_finished[run_id].set()
 
         threading.Thread(target=_background, name=f"agentflow-{run_id}", daemon=True).start()
+
+    def _graph_optimization_round_dir(self, parent_run_id: str, round_number: int) -> Path:
+        return ensure_dir(self.store.run_dir(parent_run_id) / "optimization" / f"round-{round_number:03d}")
+
+    async def _fail_graph_optimization_session(
+        self,
+        parent_run_id: str,
+        *,
+        error: str,
+        round_number: int,
+        round_dir: Path,
+    ) -> RunRecord:
+        record = self.store.get_run(parent_run_id)
+        record.status = RunStatus.FAILED
+        record.finished_at = utcnow_iso()
+        write_validation_result(round_dir / OPTIMIZER_VALIDATION_FILENAME, ok=False, error=error)
+        await self._publish(
+            parent_run_id,
+            "optimization_failed",
+            round_number=round_number,
+            error=error,
+            round_dir=str(round_dir),
+        )
+        await self._publish(parent_run_id, "run_completed", status=record.status.value)
+        await self.store.clear_cancel_request(parent_run_id)
+        await self.store.persist_run(parent_run_id)
+        self._node_cancel_flags.pop(parent_run_id, None)
+        self._pending_node_reruns.pop(parent_run_id, None)
+        return record
+
+    async def _run_graph_optimization_session(self, parent_run_id: str) -> RunRecord:
+        parent = self.store.get_run(parent_run_id)
+        optimizer_name = parent.pipeline.optimizer or ""
+        optimizer_kind = builtin_agent_kind(optimizer_name)
+        if optimizer_kind is None:
+            return await self._fail_graph_optimization_session(
+                parent_run_id,
+                error=f"invalid optimizer `{optimizer_name}`",
+                round_number=0,
+                round_dir=self.store.run_dir(parent_run_id),
+            )
+
+        parent.status = RunStatus.RUNNING
+        parent.started_at = utcnow_iso()
+        await self._publish(parent_run_id, "run_started", pipeline=parent.pipeline.model_dump(mode="json"))
+        await self.store.persist_run(parent_run_id)
+
+        optimization_session = dict(parent.optimization_session or {})
+        optimization_session.setdefault("kind", "graph")
+        optimization_session.setdefault("optimizer", optimizer_name)
+        optimization_session.setdefault("total_rounds", parent.pipeline.n_run)
+        optimization_session.setdefault("current_round", 0)
+        optimization_session.setdefault("child_run_ids", [])
+        optimization_session.setdefault("latest_pipeline_path", None)
+        parent.optimization_session = optimization_session
+
+        current_pipeline = parent.pipeline
+        final_child: RunRecord | None = None
+
+        def _optimizer_failure_summary(
+            label: str,
+            *,
+            exit_code: int | None = None,
+            stdout: str | None = None,
+            stderr: str | None = None,
+            error: str | None = None,
+        ) -> str:
+            if error is not None:
+                pieces = [error]
+            else:
+                suffix = f" exited with code {exit_code}" if exit_code is not None else " failed"
+                pieces = [f"{label}{suffix}."]
+            normalized_stdout = (stdout or "").strip()
+            normalized_stderr = (stderr or "").strip()
+            if normalized_stdout:
+                pieces.append(f"stdout:\n{normalized_stdout}")
+            if normalized_stderr:
+                pieces.append(f"stderr:\n{normalized_stderr}")
+            return "\n\n".join(pieces)
+
+        for round_number in range(1, current_pipeline.n_run + 1):
+            if self._should_cancel(parent_run_id):
+                break
+
+            round_dir = self._graph_optimization_round_dir(parent_run_id, round_number)
+            pipeline_path = round_dir / GENERATED_PIPELINE_FILENAME
+            write_editable_pipeline_python(pipeline_path, current_pipeline)
+            write_editable_pipeline_python(round_dir / GENERATED_PIPELINE_ORIGINAL_FILENAME, current_pipeline)
+
+            optimization_session["current_round"] = round_number
+            optimization_session["latest_pipeline_path"] = str(pipeline_path)
+            parent.optimization_session = optimization_session
+            parent.pipeline = current_pipeline
+            await self._publish(
+                parent_run_id,
+                "optimization_round_started",
+                round_number=round_number,
+                total_rounds=current_pipeline.n_run,
+                round_dir=str(round_dir),
+            )
+            await self.store.persist_run(parent_run_id)
+
+            child_pipeline = current_pipeline.model_copy(update={"optimizer": None, "n_run": 1})
+            child = await self._create_queued_run(
+                child_pipeline,
+                cancel_flag=self._cancel_flags[parent_run_id],
+                optimization_parent_run_id=parent_run_id,
+                optimization_round=round_number,
+            )
+            optimization_session["child_run_ids"].append(child.id)
+            parent.optimization_session = optimization_session
+            await self._publish(
+                parent_run_id,
+                "optimization_child_run_created",
+                round_number=round_number,
+                child_run_id=child.id,
+            )
+            await self.store.persist_run(parent_run_id)
+
+            try:
+                final_child = await self.run(child.id)
+            finally:
+                self._run_finished[child.id].set()
+
+            parent.nodes = deepcopy(final_child.nodes)
+            parent.pipeline = current_pipeline
+            await self._publish(
+                parent_run_id,
+                "optimization_round_completed",
+                round_number=round_number,
+                child_run_id=final_child.id,
+                child_status=final_child.status.value,
+            )
+
+            traces_dir = ensure_dir(round_dir / "traces")
+            copied_traces = copy_run_traces(final_child, self.store, traces_dir)
+            graph_report = build_graph_report(
+                parent_run_id=parent_run_id,
+                round_number=round_number,
+                total_rounds=current_pipeline.n_run,
+                run=final_child,
+                store=self.store,
+                copied_traces=copied_traces,
+            )
+            (round_dir / GRAPH_REPORT_FILENAME).write_text(json.dumps(graph_report, ensure_ascii=False, indent=2), encoding="utf-8")
+            await self.store.persist_run(parent_run_id)
+
+            if round_number >= current_pipeline.n_run or self._should_cancel(parent_run_id):
+                continue
+
+            failure_summary: str | None = None
+            loaded_pipeline: PipelineSpec | None = None
+            for attempt_number in range(1, GRAPH_OPTIMIZER_MAX_ATTEMPTS + 1):
+                attempt_dir = ensure_dir(round_dir / "attempts" / f"attempt-{attempt_number:03d}")
+                prompt = render_graph_optimizer_prompt(
+                    optimizer=optimizer_name,
+                    pipeline_path=pipeline_path,
+                    graph_report_path=round_dir / GRAPH_REPORT_FILENAME,
+                    traces_dir=traces_dir,
+                    round_number=round_number,
+                    total_rounds=current_pipeline.n_run,
+                    attempt_number=attempt_number,
+                    max_attempts=GRAPH_OPTIMIZER_MAX_ATTEMPTS,
+                    previous_failure=failure_summary,
+                )
+                (attempt_dir / OPTIMIZER_PROMPT_FILENAME).write_text(prompt, encoding="utf-8")
+                (round_dir / OPTIMIZER_PROMPT_FILENAME).write_text(prompt, encoding="utf-8")
+                await self._publish(
+                    parent_run_id,
+                    "optimization_optimizer_started",
+                    round_number=round_number,
+                    optimizer=optimizer_name,
+                    attempt_number=attempt_number,
+                    max_attempts=GRAPH_OPTIMIZER_MAX_ATTEMPTS,
+                )
+                optimizer_result = _run_optimizer(
+                    optimizer_kind,
+                    prompt=prompt,
+                    repo_dir=round_dir,
+                    runtime_dir=attempt_dir / "optimizer-runtime",
+                    env={},
+                )
+                write_optimizer_result(
+                    attempt_dir / OPTIMIZER_RESULT_FILENAME,
+                    command=optimizer_result.command,
+                    exit_code=optimizer_result.exit_code,
+                    stdout=optimizer_result.stdout,
+                    stderr=optimizer_result.stderr,
+                )
+                write_optimizer_result(
+                    round_dir / OPTIMIZER_RESULT_FILENAME,
+                    command=optimizer_result.command,
+                    exit_code=optimizer_result.exit_code,
+                    stdout=optimizer_result.stdout,
+                    stderr=optimizer_result.stderr,
+                )
+                if pipeline_path.exists():
+                    edited_text = pipeline_path.read_text(encoding="utf-8")
+                    (attempt_dir / GENERATED_PIPELINE_EDITED_FILENAME).write_text(edited_text, encoding="utf-8")
+                    (round_dir / GENERATED_PIPELINE_EDITED_FILENAME).write_text(edited_text, encoding="utf-8")
+                if optimizer_result.exit_code != 0:
+                    failure_summary = _optimizer_failure_summary(
+                        "Optimizer",
+                        exit_code=optimizer_result.exit_code,
+                        stdout=optimizer_result.stdout,
+                        stderr=optimizer_result.stderr,
+                    )
+                    write_validation_result(attempt_dir / OPTIMIZER_VALIDATION_FILENAME, ok=False, error=failure_summary)
+                    write_validation_result(round_dir / OPTIMIZER_VALIDATION_FILENAME, ok=False, error=failure_summary)
+                else:
+                    try:
+                        loaded_pipeline = load_pipeline_from_path(pipeline_path)
+                    except Exception as exc:
+                        failure_summary = _optimizer_failure_summary(
+                            "Optimized pipeline",
+                            error=f"optimized pipeline failed to load: {exc}",
+                        )
+                        write_validation_result(
+                            attempt_dir / OPTIMIZER_VALIDATION_FILENAME,
+                            ok=False,
+                            error=failure_summary,
+                        )
+                        write_validation_result(
+                            round_dir / OPTIMIZER_VALIDATION_FILENAME,
+                            ok=False,
+                            error=failure_summary,
+                        )
+                    else:
+                        write_validation_result(attempt_dir / OPTIMIZER_VALIDATION_FILENAME, ok=True)
+                        write_validation_result(round_dir / OPTIMIZER_VALIDATION_FILENAME, ok=True)
+                        break
+
+                if attempt_number < GRAPH_OPTIMIZER_MAX_ATTEMPTS:
+                    await self._publish(
+                        parent_run_id,
+                        "optimization_optimizer_retrying",
+                        round_number=round_number,
+                        attempt_number=attempt_number,
+                        error=failure_summary,
+                    )
+
+            if loaded_pipeline is None:
+                return await self._fail_graph_optimization_session(
+                    parent_run_id,
+                    error=failure_summary or "optimizer failed to produce a valid pipeline",
+                    round_number=round_number,
+                    round_dir=round_dir,
+                )
+
+            current_pipeline = loaded_pipeline.model_copy(
+                update={"optimizer": optimizer_name, "n_run": parent.pipeline.n_run}
+            )
+            parent.pipeline = current_pipeline
+            await self._publish(
+                parent_run_id,
+                "optimization_pipeline_accepted",
+                round_number=round_number,
+                attempt_number=attempt_number,
+                optimizer_output=_parse_agent_output(
+                    optimizer_kind,
+                    f"graph_optimizer_{parent_run_id}_{round_number}",
+                    optimizer_result.stdout,
+                ),
+            )
+            await self.store.persist_run(parent_run_id)
+
+        if self._should_cancel(parent_run_id):
+            parent.status = RunStatus.CANCELLED
+        elif final_child is None:
+            parent.status = RunStatus.FAILED
+        elif final_child.status == RunStatus.CANCELLED:
+            parent.status = RunStatus.CANCELLED
+        elif final_child.status == RunStatus.FAILED:
+            parent.status = RunStatus.FAILED
+        else:
+            parent.status = RunStatus.COMPLETED
+
+        parent.finished_at = utcnow_iso()
+        await self._publish(parent_run_id, "run_completed", status=parent.status.value)
+        await self.store.clear_cancel_request(parent_run_id)
+        await self.store.persist_run(parent_run_id)
+        self._node_cancel_flags.pop(parent_run_id, None)
+        self._pending_node_reruns.pop(parent_run_id, None)
+        return parent
+
+    async def submit(self, pipeline: PipelineSpec) -> RunRecord:
+        """Create a queued run and start its background scheduler when a slot opens.
+
+        Returns the newly created `RunRecord` with all nodes initialized as pending.
+        """
+        optimization_session = None
+        if pipeline.uses_graph_optimizer:
+            optimization_session = {
+                "kind": "graph",
+                "optimizer": pipeline.optimizer,
+                "total_rounds": pipeline.n_run,
+                "current_round": 0,
+                "child_run_ids": [],
+                "latest_pipeline_path": None,
+            }
+        run = await self._create_queued_run(pipeline, optimization_session=optimization_session)
+        if pipeline.uses_graph_optimizer:
+            self._start_background(run.id, lambda: self._run_graph_optimization_session(run.id))
+        else:
+            self._start_background(run.id, lambda: self.run(run.id))
         return run
 
     async def wait(self, run_id: str, timeout: float | None = None) -> RunRecord:

--- a/agentflow/specs.py
+++ b/agentflow/specs.py
@@ -84,6 +84,9 @@ class RunStatus(StrEnum):
     FAILED = "failed"
 
 
+_INTERACTIVE_AGENT_KINDS = {AgentKind.CODEX, AgentKind.CLAUDE, AgentKind.KIMI}
+
+
 def normalize_agent_name(value: str | AgentKind) -> str:
     if isinstance(value, AgentKind):
         return value.value
@@ -1429,6 +1432,8 @@ class PipelineSpec(BaseModel):
     name: str
     description: str | None = None
     working_dir: str = "."
+    optimizer: str | None = None
+    n_run: int = Field(default=1, ge=1)
     concurrency: int = Field(default=4, ge=1)
     fail_fast: bool = False
     max_iterations: int = Field(default=10, ge=1)
@@ -1453,6 +1458,21 @@ class PipelineSpec(BaseModel):
 
     @model_validator(mode="after")
     def validate_nodes(self) -> "PipelineSpec":
+        if self.optimizer is not None:
+            normalized_optimizer = self.optimizer.strip()
+            if not normalized_optimizer:
+                raise ValueError("`optimizer` must not be empty")
+            optimizer_kind = builtin_agent_kind(normalized_optimizer)
+            if optimizer_kind is None or optimizer_kind not in _INTERACTIVE_AGENT_KINDS:
+                supported = ", ".join(f"`{agent.value}`" for agent in sorted(_INTERACTIVE_AGENT_KINDS, key=lambda agent: agent.value))
+                raise ValueError(f"`optimizer` must be one of {supported}")
+            self.optimizer = normalized_optimizer
+        elif self.n_run > 1:
+            raise ValueError("`optimizer` is required when `n_run` is greater than 1")
+
+        if not self.nodes:
+            raise ValueError("pipeline must contain at least one node")
+
         ids = [node.id for node in self.nodes]
         duplicates = {node_id for node_id in ids if ids.count(node_id) > 1}
         if duplicates:
@@ -1501,6 +1521,10 @@ class PipelineSpec(BaseModel):
     @property
     def working_path(self) -> Path:
         return Path(self.working_dir).expanduser().resolve()
+
+    @property
+    def uses_graph_optimizer(self) -> bool:
+        return self.optimizer is not None and self.n_run > 1
 
 
 class NormalizedTraceEvent(BaseModel):
@@ -1560,6 +1584,9 @@ class RunRecord(BaseModel):
     id: str
     status: RunStatus = RunStatus.QUEUED
     pipeline: PipelineSpec
+    optimization_parent_run_id: str | None = None
+    optimization_round: int | None = Field(default=None, ge=1)
+    optimization_session: dict[str, Any] | None = None
     created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     started_at: str | None = None
     finished_at: str | None = None

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -154,6 +154,19 @@ def test_dag_and_node_repr_and_payload_isolation():
     assert plan.depends_on == []
 
 
+def test_graph_supports_optimizer_and_n_run():
+    with Graph("opt-demo", optimizer="codex", n_run=3) as dag:
+        codex(task_id="plan", prompt="plan")
+
+    payload = dag.to_payload()
+    spec = dag.to_spec()
+
+    assert payload["optimizer"] == "codex"
+    assert payload["n_run"] == 3
+    assert spec.optimizer == "codex"
+    assert spec.n_run == 3
+
+
 def test_airflow_like_dag_applies_local_target_defaults():
     with Graph(
         "local-defaults",

--- a/tests/test_graph_optimizer.py
+++ b/tests/test_graph_optimizer.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agentflow.graph_optimizer import (
+    GRAPH_OPTIMIZER_MAX_ATTEMPTS,
+    GENERATED_PIPELINE_EDITED_FILENAME,
+    GENERATED_PIPELINE_ORIGINAL_FILENAME,
+    OPTIMIZER_VALIDATION_FILENAME,
+    editable_pipeline_payload,
+    render_graph_optimizer_prompt,
+    write_editable_pipeline_python,
+)
+from agentflow.loader import load_pipeline_from_path
+from agentflow.specs import PipelineSpec, RunStatus
+from agentflow.tuned_agents import CommandExecution
+from tests.test_orchestrator import make_orchestrator
+
+
+def test_editable_pipeline_python_round_trips(tmp_path):
+    pipeline = PipelineSpec.model_validate(
+        {
+            "name": "roundtrip",
+            "working_dir": str(tmp_path),
+            "concurrency": 2,
+            "nodes": [
+                {"id": "plan", "agent": "codex", "prompt": "plan"},
+                {"id": "review", "agent": "claude", "prompt": "review", "depends_on": ["plan"]},
+            ],
+        }
+    )
+    pipeline_path = tmp_path / "pipeline.py"
+
+    write_editable_pipeline_python(pipeline_path, pipeline)
+    loaded = load_pipeline_from_path(pipeline_path)
+
+    payload = loaded.model_dump(mode="json")
+    payload.pop("optimizer", None)
+    payload.pop("n_run", None)
+    assert payload == editable_pipeline_payload(pipeline)
+
+
+def test_pipeline_spec_requires_optimizer_when_n_run_exceeds_one(tmp_path):
+    with pytest.raises(ValueError, match="`optimizer` is required"):
+        PipelineSpec.model_validate(
+            {
+                "name": "bad",
+                "working_dir": str(tmp_path),
+                "n_run": 2,
+                "nodes": [{"id": "plan", "agent": "codex", "prompt": "hi"}],
+            }
+        )
+
+
+def test_pipeline_spec_requires_at_least_one_node(tmp_path):
+    with pytest.raises(ValidationError, match="pipeline must contain at least one node"):
+        PipelineSpec.model_validate(
+            {
+                "name": "empty",
+                "working_dir": str(tmp_path),
+                "nodes": [],
+            }
+        )
+
+
+def test_graph_optimizer_prompt_includes_goal_guardrails_and_validation(tmp_path):
+    prompt = render_graph_optimizer_prompt(
+        optimizer="codex",
+        pipeline_path=tmp_path / "pipeline.py",
+        graph_report_path=tmp_path / "graph_report.json",
+        traces_dir=tmp_path / "traces",
+        round_number=2,
+        total_rounds=5,
+        attempt_number=1,
+        max_attempts=GRAPH_OPTIMIZER_MAX_ATTEMPTS,
+        previous_failure=None,
+    )
+
+    assert "Goal:" in prompt
+    assert "Working materials:" in prompt
+    assert "Allowed graph changes:" in prompt
+    assert "Guardrails:" in prompt
+    assert "Validation checklist before finishing:" in prompt
+    assert "Keep at least one node in the graph." in prompt
+    assert "The resulting pipeline validates cleanly and contains at least one node." in prompt
+
+
+def test_orchestrator_runs_graph_optimization_rounds(tmp_path, monkeypatch):
+    orchestrator = make_orchestrator(tmp_path)
+
+    def fake_optimizer(_optimizer, *, prompt: str, repo_dir: Path, runtime_dir: Path, env: dict[str, str]):
+        pipeline_path = repo_dir / "pipeline.py"
+        text = pipeline_path.read_text(encoding="utf-8")
+        pipeline_path.write_text(text.replace("round one", "round two"), encoding="utf-8")
+        return CommandExecution(command="optimizer", exit_code=0, stdout="updated pipeline", stderr="")
+
+    monkeypatch.setattr("agentflow.orchestrator._run_optimizer", fake_optimizer)
+
+    pipeline = PipelineSpec.model_validate(
+        {
+            "name": "graph-opt",
+            "working_dir": str(tmp_path),
+            "optimizer": "codex",
+            "n_run": 2,
+            "nodes": [{"id": "plan", "agent": "codex", "prompt": "round one"}],
+        }
+    )
+
+    run = asyncio.run(orchestrator.submit(pipeline))
+    completed = asyncio.run(orchestrator.wait(run.id, timeout=5))
+
+    assert completed.status == RunStatus.COMPLETED
+    assert completed.nodes["plan"].output == "round two"
+    assert completed.optimization_session is not None
+    child_run_ids = completed.optimization_session["child_run_ids"]
+    assert len(child_run_ids) == 2
+    assert orchestrator.store.get_run(child_run_ids[0]).nodes["plan"].output == "round one"
+    assert orchestrator.store.get_run(child_run_ids[1]).nodes["plan"].output == "round two"
+
+    round_one_dir = orchestrator.store.run_dir(run.id) / "optimization" / "round-001"
+    assert (round_one_dir / GENERATED_PIPELINE_ORIGINAL_FILENAME).exists()
+    assert (round_one_dir / GENERATED_PIPELINE_EDITED_FILENAME).exists()
+
+
+def test_orchestrator_retries_invalid_optimized_pipeline_with_error_context(tmp_path, monkeypatch):
+    orchestrator = make_orchestrator(tmp_path)
+    prompts: list[str] = []
+    attempt_state = {"count": 0}
+
+    def fake_optimizer(_optimizer, *, prompt: str, repo_dir: Path, runtime_dir: Path, env: dict[str, str]):
+        prompts.append(prompt)
+        attempt_state["count"] += 1
+        pipeline_path = repo_dir / "pipeline.py"
+        if attempt_state["count"] == 1:
+            pipeline_path.write_text("from __future__ import annotations\n\nthis is not valid python\n", encoding="utf-8")
+        else:
+            pipeline_path.write_text(
+                (
+                    "from __future__ import annotations\n\n"
+                    "import json\n\n"
+                    "PIPELINE = {\n"
+                    f"    'name': 'graph-opt-retry',\n"
+                    f"    'working_dir': {str(tmp_path)!r},\n"
+                    "    'nodes': [\n"
+                    "        {'id': 'plan', 'agent': 'codex', 'prompt': 'round two'},\n"
+                    "    ],\n"
+                    "}\n\n"
+                    "if __name__ == '__main__':\n"
+                    "    print(json.dumps(PIPELINE, ensure_ascii=False, indent=2))\n"
+                ),
+                encoding="utf-8",
+            )
+        return CommandExecution(command="optimizer", exit_code=0, stdout="updated pipeline", stderr="")
+
+    monkeypatch.setattr("agentflow.orchestrator._run_optimizer", fake_optimizer)
+
+    pipeline = PipelineSpec.model_validate(
+        {
+            "name": "graph-opt-retry",
+            "working_dir": str(tmp_path),
+            "optimizer": "codex",
+            "n_run": 2,
+            "nodes": [{"id": "plan", "agent": "codex", "prompt": "round one"}],
+        }
+    )
+
+    run = asyncio.run(orchestrator.submit(pipeline))
+    completed = asyncio.run(orchestrator.wait(run.id, timeout=5))
+
+    assert completed.status == RunStatus.COMPLETED
+    assert completed.nodes["plan"].output == "round two"
+    assert attempt_state["count"] == 2
+    assert "Previous optimizer/load failure to fix before finishing" in prompts[1]
+    assert "optimized pipeline failed to load" in prompts[1]
+
+
+def test_orchestrator_fails_when_optimized_pipeline_is_invalid(tmp_path, monkeypatch):
+    orchestrator = make_orchestrator(tmp_path)
+    attempt_state = {"count": 0}
+
+    def fake_optimizer(_optimizer, *, prompt: str, repo_dir: Path, runtime_dir: Path, env: dict[str, str]):
+        attempt_state["count"] += 1
+        pipeline_path = repo_dir / "pipeline.py"
+        pipeline_path.write_text("from __future__ import annotations\n\nthis is not valid python\n", encoding="utf-8")
+        return CommandExecution(command="optimizer", exit_code=0, stdout="broken pipeline", stderr="")
+
+    monkeypatch.setattr("agentflow.orchestrator._run_optimizer", fake_optimizer)
+
+    pipeline = PipelineSpec.model_validate(
+        {
+            "name": "graph-opt-invalid",
+            "working_dir": str(tmp_path),
+            "optimizer": "codex",
+            "n_run": 2,
+            "nodes": [{"id": "plan", "agent": "codex", "prompt": "round one"}],
+        }
+    )
+
+    run = asyncio.run(orchestrator.submit(pipeline))
+    completed = asyncio.run(orchestrator.wait(run.id, timeout=5))
+
+    assert completed.status == RunStatus.FAILED
+    assert completed.optimization_session is not None
+    assert len(completed.optimization_session["child_run_ids"]) == 1
+    assert attempt_state["count"] == GRAPH_OPTIMIZER_MAX_ATTEMPTS
+
+    validation_payload = json.loads(
+        (orchestrator.store.run_dir(run.id) / "optimization" / "round-001" / OPTIMIZER_VALIDATION_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert validation_payload["ok"] is False
+    assert "failed to load" in validation_payload["error"]


### PR DESCRIPTION
## Summary
- add graph-level iterative optimization via `Graph(..., optimizer=..., n_run=...)`
- generate editable per-round `pipeline.py` plus graph report and copied traces for the optimizer
- validate optimized pipelines, require at least one node, and retry optimization with pasted load/validation errors when the optimizer produces a broken pipeline

## Testing
- `PYTHONPATH=/home/c/agentflow python3 -m pytest tests/test_dsl.py tests/test_loader.py tests/test_graph_optimizer.py tests/test_tuned_agents.py tests/test_api.py tests/test_traces.py -q`

## Notes
- `tests/test_orchestrator.py` was not run end-to-end here because `pytest-asyncio` is not installed in this environment.