### PR TITLE
complete graph optimization rounds docs and codex smoke verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-results/
 dist/
 *.egg-info/
 .worktrees/
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -146,6 +146,29 @@ with Graph("campaign", scratchboard=True) as g:
 | `ec2_remote.py` | Run codex on a remote EC2 instance |
 | `ecs_fargate.py` | Run codex on ECS Fargate |
 
+## Graph Optimization Rounds
+
+Run multiple optimization rounds over your graph with top-level `optimizer` and `n_run`. Use this when you want AgentFlow to let the optimizer rewrite the graph between rounds; the validation step only checks that the edited pipeline loads and passes schema validation, not that the edits are semantically better.
+
+Artifacts and logs for each round live under `.agentflow/runs/<run_id>/optimization/round-XXX/`.
+
+```python
+from agentflow import Graph, codex
+
+with Graph(
+    "optimization-demo",
+    optimizer="codex",
+    n_run=2,
+    concurrency=2,
+) as g:
+    plan = codex(task_id="plan", prompt="Outline the tasks required to finish the ticket.")
+    review = codex(task_id="review", prompt="Review the plan for missing steps or risks.")
+    summary = codex(task_id="summary", prompt="Summarize the approved plan and next actions.")
+    plan >> review >> summary
+
+print(g.to_json())
+```
+
 ## CLI
 
 ```bash

--- a/agentflow/tuned_agents.py
+++ b/agentflow/tuned_agents.py
@@ -323,6 +323,8 @@ def _app_root() -> Path:
 
 
 def _execution_paths(cwd: Path, runtime_dir: Path) -> ExecutionPaths:
+    cwd = cwd.resolve()
+    runtime_dir = runtime_dir.resolve()
     ensure_dir(runtime_dir)
     return ExecutionPaths(
         host_workdir=cwd,
@@ -343,14 +345,19 @@ def _materialize_runtime_files(prepared: PreparedExecution, runtime_dir: Path) -
 def _run_prepared(prepared: PreparedExecution) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(prepared.env)
-    return subprocess.run(
-        prepared.command,
-        cwd=prepared.cwd,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    run_kwargs: dict[str, object] = {
+        "cwd": prepared.cwd,
+        "env": env,
+        "capture_output": True,
+        "text": True,
+        "check": False,
+    }
+    if prepared.stdin is None:
+        run_kwargs["stdin"] = subprocess.DEVNULL
+    else:
+        run_kwargs["stdin"] = subprocess.PIPE
+        run_kwargs["input"] = prepared.stdin
+    return subprocess.run(prepared.command, **run_kwargs)
 
 
 def _parse_agent_output(agent: AgentKind, node_id: str, stdout: str) -> str:
@@ -377,14 +384,32 @@ def _run_optimizer(
     runtime_dir: Path,
     env: dict[str, str],
 ) -> CommandExecution:
+    normalized_env = dict(env)
+    ambient_openai_base_url = (
+        normalized_env.get("OPENAI_BASE_URL")
+        or normalized_env.get("AGENTFLOW_OPENAI_BASE_URL")
+        or os.environ.get("OPENAI_BASE_URL")
+        or os.environ.get("AGENTFLOW_OPENAI_BASE_URL")
+    )
+    provider: dict[str, str] | None = None
+    if optimizer == AgentKind.CODEX and ambient_openai_base_url:
+        normalized_env.setdefault("OPENAI_BASE_URL", ambient_openai_base_url)
+        provider = {
+            "name": "openai-custom",
+            "base_url": ambient_openai_base_url,
+            "api_key_env": "OPENAI_API_KEY",
+            "wire_api": "responses",
+        }
     node = NodeSpec.model_validate(
         {
             "id": "optimizer",
             "agent": optimizer.value,
             "prompt": prompt,
             "tools": "read_write",
+            "provider": provider,
+            "repo_instructions_mode": "ignore",
             "target": {"kind": "local", "cwd": str(repo_dir)},
-            "env": env,
+            "env": normalized_env,
         }
     )
     adapter = default_adapter_registry.get(optimizer)

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -63,6 +63,8 @@ Top-level pipeline controls include:
 - `fail_fast`: skip downstream work after the first failed node
 - `node_defaults`: shared node fields merged into every node before validation
 - `agent_defaults`: agent-specific shared node fields keyed by `codex`, `claude`, or `kimi`
+- `optimizer`: optional optimizer backend, one of `codex`, `claude`, or `kimi`
+- `n_run`: optional integer; when `> 1`, runs optimization rounds before execution
 
 `node_defaults` is the pipeline-wide baseline. `agent_defaults` is the agent-specific override layer. Explicit node values always win.
 
@@ -84,6 +86,19 @@ DAG(
     },
 )
 ```
+
+## Graph optimization rounds
+
+Set top-level `optimizer` and `n_run` to run optimization rounds over the graph before execution. When `n_run > 1`, AgentFlow runs per-round optimization behavior and writes artifacts under `.agentflow/runs/<run_id>/optimization/round-XXX/`:
+
+- `pipeline.original.py`
+- `pipeline.edited.py`
+- `graph_report.json`
+- `optimizer-prompt.txt`
+- `optimizer-result.json`
+- `optimizer-validation.json`
+
+Validation safeguards ensure the edited pipeline still loads and matches the pipeline schema. These checks only validate loader and schema correctness; they do not guarantee semantic improvement or better runtime results.
 
 ## Fan-out and merge
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,22 @@ make test
 
 That shortcut uses the same interpreter resolution as the other repo-local helpers: `.venv/bin/python` when the repo virtualenv exists, otherwise `python3`. Run `make python` when you want to confirm which interpreter those shortcuts will use on your machine.
 
+## Graph Optimization Verification
+
+For maintainer checks of graph optimization rounds, run the focused tests using the repo virtualenv when available:
+
+```bash
+.venv/bin/python -m pytest tests/test_loader.py tests/test_dsl.py tests/test_graph_optimizer.py -q
+```
+
+Then run a real smoke example with the AgentFlow CLI and capture the summary output:
+
+```bash
+.venv/bin/python -m agentflow run examples/graph_optimization_rounds.py --output summary
+```
+
+Inspect the generated artifacts under `.agentflow/runs/<run_id>/optimization/round-XXX/`, especially `pipeline.original.py`, `pipeline.edited.py`, `graph_report.json`, `optimizer-prompt.txt`, `optimizer-result.json`, and `optimizer-validation.json`. Those validation files confirm the edited pipeline still loads and passes schema validation, but they do not imply the edits are semantically better.
+
 Run the browser suite:
 
 ```bash
@@ -61,4 +77,3 @@ agentflow doctor
 When `codex` or `claude` are already on `PATH`, the doctor summary now includes the resolved executable path and `--version` output to make local CLI mismatches easier to spot. Use `agentflow doctor --output json-summary` when you want the compact machine-readable summary payload that matches the other orchestration commands, or `--output json` when you need each check's full `context`.
 
 The bundled smoke pipeline bootstraps the `kimi` shell helper inside both local nodes, so you do not need to wrap the entire `agentflow smoke` command in `bash -lic`. If you want to run a custom smoke pipeline instead, pass its path explicitly with `agentflow smoke path/to/pipeline.yaml`, or run it directly with `agentflow run path/to/pipeline.yaml` and keep the same `auto` preflight behavior for bundled and Kimi-bootstrapped local smoke pipelines. `run` now mirrors `smoke` by defaulting to the compact summary on an interactive terminal while still falling back to full JSON when stdout is redirected. Use `--preflight always` for other custom pipelines that still need those checks; forced preflight still follows the agents and bootstrap that your pipeline actually uses. Use `--preflight never` to skip preflight even for the bundled example. Add `--output json-summary` when you want a concise machine-readable result, or `--output json` when you want the full persisted run record instead of the compact summary.
-

--- a/examples/graph_optimization_rounds.py
+++ b/examples/graph_optimization_rounds.py
@@ -1,0 +1,50 @@
+"""Loader-consumable example that prints only pipeline JSON when executed.
+
+`load_pipeline_from_path()` executes Python examples from the example directory,
+so we prepend the repo root when needed to keep this loader-consumable in a
+repo checkout without relying on an editable installation.
+"""
+
+import os
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from agentflow import Graph, codex
+
+optimizer = "codex"  # agent used to patch the graph between rounds
+n_run = 2  # total optimization rounds
+provider = {
+    "name": "openai-custom",
+    "base_url": os.environ.get("AGENTFLOW_OPENAI_BASE_URL") or os.environ.get("OPENAI_BASE_URL"),
+    "api_key_env": "OPENAI_API_KEY",
+    "wire_api": "responses",
+}
+
+with Graph("graph-optimization-rounds", optimizer=optimizer, n_run=n_run, concurrency=2) as g:
+    plan = codex(
+        task_id="plan",
+        prompt="Draft a short implementation plan.",
+        provider=provider,
+        repo_instructions_mode="ignore",
+    )
+    review = codex(
+        task_id="review",
+        prompt="Review the plan for gaps and missing steps.",
+        provider=provider,
+        repo_instructions_mode="ignore",
+    )
+    summary = codex(
+        task_id="summary",
+        prompt="Summarize the approved plan and next actions.",
+        provider=provider,
+        repo_instructions_mode="ignore",
+    )
+
+    plan >> review >> summary
+
+if __name__ == "__main__":
+    print(g.to_json())

--- a/scripts/smoke_graph_optimization_rounds.sh
+++ b/scripts/smoke_graph_optimization_rounds.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -x ".venv/bin/python" ]]; then
+  PYTHON=".venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "missing required environment variable: OPENAI_API_KEY" >&2
+  exit 1
+fi
+
+if [[ -z "${AGENTFLOW_OPENAI_BASE_URL:-}" && -z "${OPENAI_BASE_URL:-}" ]]; then
+  echo "missing required environment variable: AGENTFLOW_OPENAI_BASE_URL or OPENAI_BASE_URL" >&2
+  exit 1
+fi
+
+latest_parent_run() {
+  "$PYTHON" - <<'PY'
+import json
+from pathlib import Path
+
+candidates = []
+for path in Path(".agentflow/runs").glob("*"):
+    run_json = path / "run.json"
+    if not run_json.exists():
+        continue
+    data = json.loads(run_json.read_text())
+    pipeline = data.get("pipeline", {})
+    if data.get("optimization_parent_run_id") is None and pipeline.get("optimizer") == "codex" and pipeline.get("n_run") == 2:
+        candidates.append((path.stat().st_mtime, path))
+
+print(candidates and str(sorted(candidates)[-1][1]) or "")
+PY
+}
+
+before_latest="$(latest_parent_run)"
+
+"$PYTHON" -m agentflow run examples/graph_optimization_rounds.py --output summary
+
+after_latest="$(latest_parent_run)"
+if [[ -z "$after_latest" || "$after_latest" == "$before_latest" ]]; then
+  echo "failed to detect a new run directory" >&2
+  exit 1
+fi
+
+round_dir="$after_latest/optimization/round-001"
+round_two_dir="$after_latest/optimization/round-002"
+
+for path in \
+  "$round_dir/pipeline.original.py" \
+  "$round_dir/pipeline.edited.py" \
+  "$round_dir/graph_report.json" \
+  "$round_dir/optimizer-prompt.txt" \
+  "$round_dir/optimizer-result.json" \
+  "$round_dir/optimizer-validation.json" \
+  "$round_two_dir/pipeline.original.py" \
+  "$round_two_dir/pipeline.py" \
+  "$round_two_dir/graph_report.json"
+do
+  if [[ ! -f "$path" ]]; then
+    echo "missing expected artifact: $path" >&2
+    exit 1
+  fi
+done
+
+echo "graph optimization smoke run passed"
+echo "run_dir=$after_latest"

--- a/skills/agentflow/SKILL.md
+++ b/skills/agentflow/SKILL.md
@@ -12,7 +12,12 @@ Build multi-agent pipelines where codex, claude, and kimi work together in depen
 ```python
 from agentflow import Graph, codex, claude
 
-with Graph("review-pipeline", concurrency=3) as g:
+with Graph(
+    "review-pipeline",
+    concurrency=3,
+    optimizer="codex",
+    n_run=2,
+) as g:
     plan = codex(task_id="plan", prompt="Plan the work.", tools="read_only")
     impl = claude(task_id="impl", prompt="Implement:\n{{ nodes.plan.output }}", tools="read_write")
     review = codex(task_id="review", prompt="Review:\n{{ nodes.impl.output }}")
@@ -22,6 +27,8 @@ print(g.to_json())
 ```
 
 Run: `agentflow run pipeline.py`
+
+Setting `optimizer` and `n_run` like this runs graph optimization between rounds, so Codex can rewrite the graph and the runtime can verify that the edited pipeline still loads and matches schema before the next round runs.
 
 ## Imports
 
@@ -240,6 +247,44 @@ Graph("name",
     node_defaults={...},     # defaults for all nodes
     agent_defaults={...},    # per-agent defaults
 )
+```
+
+Add optimizer controls when you want AgentFlow to rewrite the graph before execution:
+
+- `optimizer`: the interactive agent (one of `codex`, `claude`, `kimi`) that rewrites the graph for the next round.
+- `n_run`: total number of graph rounds to execute; set it to `2` or higher to enable optimization rounds before the final run.
+
+## Graph Optimization Rounds
+
+Use top-level `optimizer` and `n_run` to run optimization rounds on the pipeline graph before execution.
+Supported optimizers: `codex`, `claude`, `kimi`.
+Set `n_run > 1` to enable per-round optimization behavior.
+
+Artifacts and logs are written under `.agentflow/runs/<run_id>/optimization/round-XXX/`:
+- `pipeline.original.py`
+- `pipeline.edited.py`
+- `graph_report.json`
+- `optimizer-prompt.txt`
+- `optimizer-result.json`
+- `optimizer-validation.json`
+
+Example pipeline with optimizer rounds:
+
+```python
+from agentflow import Graph, codex
+
+with Graph(
+    "optimization-demo",
+    optimizer="codex",
+    n_run=2,
+    concurrency=2,
+) as g:
+    plan = codex(task_id="plan", prompt="Outline the tasks in the ticket.")
+    review = codex(task_id="review", prompt="Review the plan for missing steps.")
+    summary = codex(task_id="summary", prompt="Summarize approved next actions.")
+    plan >> review >> summary
+
+print(g.to_json())
 ```
 
 ## CLI

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from agentflow.loader import load_pipeline_from_data, load_pipeline_from_path, load_pipeline_from_text
 
@@ -420,3 +421,26 @@ def test_load_pipeline_from_text_expands_batched_fanout_before_resolving_relativ
     assert pipeline.node_map["batch_merge_1"].depends_on == ["fuzz_2", "fuzz_3"]
     assert pipeline.node_map["batch_merge_2"].depends_on == ["fuzz_4"]
 
+
+def test_load_graph_optimization_rounds_example():
+    repo_root = Path(__file__).resolve().parents[1]
+    example_path = repo_root / "examples" / "graph_optimization_rounds.py"
+
+    pipeline = load_pipeline_from_path(example_path)
+
+    assert pipeline.optimizer == "codex"
+    assert pipeline.n_run == 2
+    assert pipeline.uses_graph_optimizer is True
+    assert set(pipeline.node_map) == {"plan", "review", "summary"}
+    assert len(pipeline.nodes) == 3
+    assert pipeline.node_map["plan"].agent == "codex"
+    assert pipeline.node_map["review"].agent == "codex"
+    assert pipeline.node_map["summary"].agent == "codex"
+    assert pipeline.node_map["plan"].provider.name == "openai-custom"
+    assert pipeline.node_map["review"].provider.name == "openai-custom"
+    assert pipeline.node_map["summary"].provider.name == "openai-custom"
+    assert pipeline.node_map["plan"].repo_instructions_mode == "ignore"
+    assert pipeline.node_map["review"].repo_instructions_mode == "ignore"
+    assert pipeline.node_map["summary"].repo_instructions_mode == "ignore"
+    assert pipeline.node_map["review"].depends_on == ["plan"]
+    assert pipeline.node_map["summary"].depends_on == ["review"]

--- a/tests/test_tuned_agents.py
+++ b/tests/test_tuned_agents.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 from pathlib import Path
 
 import agentflow.cli
@@ -12,7 +13,7 @@ from agentflow.inspection import build_launch_inspection
 from agentflow.orchestrator import Orchestrator
 from agentflow.prepared import ExecutionPaths, PreparedExecution
 from agentflow.runners.registry import RunnerRegistry
-from agentflow.specs import AgentKind, NodeSpec, PipelineSpec, RunRecord, RunStatus
+from agentflow.specs import AgentKind, NodeSpec, PipelineSpec, RepoInstructionsMode, RunRecord, RunStatus
 from agentflow.store import RunStore
 from agentflow.tuned_agents import (
     CommandExecution,
@@ -21,7 +22,10 @@ from agentflow.tuned_agents import (
     list_tuned_agent_records,
     load_tuner_config,
     load_tuned_agent_registry,
+    _execution_paths,
     _optimizer_prompt,
+    _run_optimizer,
+    _run_prepared,
     register_tuned_agent_version,
     ResolvedTunerConfig,
     TunerConfig,
@@ -43,6 +47,138 @@ class SimpleCodexAdapter(AgentAdapter):
             cwd=paths.target_workdir,
             trace_kind="codex",
         )
+
+
+def test_run_prepared_closes_stdin_when_none(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args[0], 0, "", "")
+
+    monkeypatch.setattr("agentflow.tuned_agents.subprocess.run", fake_run)
+
+    prepared = PreparedExecution(
+        command=["echo", "hi"],
+        env={},
+        cwd=".",
+        trace_kind="codex",
+        stdin=None,
+    )
+
+    _run_prepared(prepared)
+
+    assert captured["kwargs"]["stdin"] is subprocess.DEVNULL
+
+
+def test_run_optimizer_ignores_repo_instructions(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class FakeAdapter(AgentAdapter):
+        def prepare(self, node, prompt: str, paths: ExecutionPaths) -> PreparedExecution:
+            captured["node"] = node
+            return PreparedExecution(
+                command=["echo", "optimizer"],
+                env={},
+                cwd=str(tmp_path),
+                trace_kind="codex",
+            )
+
+    def fake_get(_agent):
+        return FakeAdapter()
+
+    def fake_paths(repo_dir: Path, runtime_dir: Path) -> ExecutionPaths:
+        return ExecutionPaths(
+            host_workdir=repo_dir,
+            host_runtime_dir=runtime_dir,
+            target_workdir=str(repo_dir),
+            target_runtime_dir=str(runtime_dir),
+            app_root=repo_dir,
+        )
+
+    def fake_materialize(*_args, **_kwargs) -> None:
+        return None
+
+    def fake_run_prepared(_prepared: PreparedExecution) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["echo"], 0, "", "")
+
+    monkeypatch.setattr("agentflow.tuned_agents.default_adapter_registry.get", fake_get)
+    monkeypatch.setattr("agentflow.tuned_agents._execution_paths", fake_paths)
+    monkeypatch.setattr("agentflow.tuned_agents._materialize_runtime_files", fake_materialize)
+    monkeypatch.setattr("agentflow.tuned_agents._run_prepared", fake_run_prepared)
+
+    _run_optimizer(
+        AgentKind.CODEX,
+        prompt="optimize",
+        repo_dir=tmp_path / "repo",
+        runtime_dir=tmp_path / "runtime",
+        env={},
+    )
+
+    assert captured["node"].repo_instructions_mode == RepoInstructionsMode.IGNORE
+
+
+def test_run_optimizer_uses_openai_provider_when_base_url_is_present(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class FakeAdapter(AgentAdapter):
+        def prepare(self, node, prompt: str, paths: ExecutionPaths) -> PreparedExecution:
+            captured["node"] = node
+            return PreparedExecution(
+                command=["echo", "optimizer"],
+                env={},
+                cwd=str(tmp_path),
+                trace_kind="codex",
+            )
+
+    def fake_get(_agent):
+        return FakeAdapter()
+
+    def fake_paths(repo_dir: Path, runtime_dir: Path) -> ExecutionPaths:
+        return ExecutionPaths(
+            host_workdir=repo_dir,
+            host_runtime_dir=runtime_dir,
+            target_workdir=str(repo_dir),
+            target_runtime_dir=str(runtime_dir),
+            app_root=repo_dir,
+        )
+
+    def fake_materialize(*_args, **_kwargs) -> None:
+        return None
+
+    def fake_run_prepared(_prepared: PreparedExecution) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["echo"], 0, "", "")
+
+    monkeypatch.setattr("agentflow.tuned_agents.default_adapter_registry.get", fake_get)
+    monkeypatch.setattr("agentflow.tuned_agents._execution_paths", fake_paths)
+    monkeypatch.setattr("agentflow.tuned_agents._materialize_runtime_files", fake_materialize)
+    monkeypatch.setattr("agentflow.tuned_agents._run_prepared", fake_run_prepared)
+
+    _run_optimizer(
+        AgentKind.CODEX,
+        prompt="optimize",
+        repo_dir=tmp_path / "repo",
+        runtime_dir=tmp_path / "runtime",
+        env={"AGENTFLOW_OPENAI_BASE_URL": "http://relay.example/openai"},
+    )
+
+    assert captured["node"].provider is not None
+    assert captured["node"].provider.name == "openai-custom"
+    assert captured["node"].provider.base_url == "http://relay.example/openai"
+    assert captured["node"].provider.wire_api == "responses"
+    assert captured["node"].env["OPENAI_BASE_URL"] == "http://relay.example/openai"
+
+
+def test_execution_paths_resolve_relative_inputs(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    paths = _execution_paths(Path("repo"), Path("runtime"))
+
+    assert paths.target_workdir == str(tmp_path / "repo")
+    assert paths.target_runtime_dir == str(tmp_path / "runtime")
+    assert Path(paths.target_workdir).is_absolute()
+    assert Path(paths.target_runtime_dir).is_absolute()
 
 
 def test_loader_supports_yaml_pipeline(tmp_path):


### PR DESCRIPTION
## Summary

This follow-up completes the delivery work around PR #12 graph optimization rounds.

It does not reintroduce PR #12 itself. Instead, it makes the merged feature verifiable and usable:

- documents graph optimization rounds in the skill
- documents graph optimization rounds in README
- documents graph optimization rounds in the pipeline/testing docs
- adds a minimal codex-only graph optimization example
- adds a minimal smoke script for local verification
- fixes direct blockers found during real local verification

## What Changed

### Docs

- updated `skills/agentflow/SKILL.md`
- updated `README.md`
- updated `docs/pipelines.md`
- updated `docs/testing.md`

### Example / Verification

- added `examples/graph_optimization_rounds.py`
- added `scripts/smoke_graph_optimization_rounds.sh`
- added loader coverage for the example

### Direct blocker fixes found during local verification

- fixed optimizer subprocess stdin handling so `codex exec` does not hang waiting for stdin EOF
- made internal optimizer ignore repo instructions to reduce repo-specific interference
- resolved tuned-agent execution paths to absolute paths so `CODEX_HOME` works correctly
- added custom OpenAI Responses provider handling for codex-based smoke verification with a non-default base URL

## Local Verification

Ran:

```sh
pytest tests/test_dsl.py \
  tests/test_loader.py \
  tests/test_graph_optimizer.py \
  tests/test_tuned_agents.py \
  tests/test_api.py \
  tests/test_traces.py -q
```

Result:

```text
68 passed
```

Ran:

```sh
./scripts/smoke_graph_optimization_rounds.sh
```

Result:

```text
Run 87adff9aff394a4c8f9806840af8fd03: completed
...
graph optimization smoke run passed
run_dir=.agentflow/runs/87adff9aff394a4c8f9806840af8fd03
```

Verified artifacts:

```sh
.agentflow/runs/87adff9aff394a4c8f9806840af8fd03/optimization/
├── round-001
│   ├── attempts
│   ├── graph_report.json
│   ├── optimizer-prompt.txt
│   ├── optimizer-result.json
│   ├── optimizer-validation.json
│   ├── pipeline.edited.py
│   ├── pipeline.original.py
│   ├── pipeline.py
│   └── traces
└── round-002
    ├── graph_report.json
    ├── pipeline.original.py
    ├── pipeline.py
    └── traces