### PR TITLE
Add exponential backoff and resume command for outage resilience

### DIFF
--- a/agentflow/cli.py
+++ b/agentflow/cli.py
@@ -2187,6 +2187,42 @@ def rerun(
 
 
 @app.command()
+def resume(
+    run_id: str,
+    runs_dir: str = typer.Option(".agentflow/runs", envvar="AGENTFLOW_RUNS_DIR"),
+    max_concurrent_runs: int = typer.Option(2, envvar="AGENTFLOW_MAX_CONCURRENT_RUNS"),
+    output: RunOutputFormat = typer.Option(
+        RunOutputFormat.AUTO,
+        "--output",
+        help="Result output format. Defaults to `summary` on a terminal and `json` otherwise.",
+    ),
+) -> None:
+    """Resume a failed or cancelled run from where it left off.
+
+    Completed nodes are preserved and skipped; failed/cancelled/skipped nodes
+    are reset to pending and re-executed. The scratchboard and artifacts from
+    completed nodes are copied to the new run.
+    """
+    store, orchestrator = _build_runtime(runs_dir, max_concurrent_runs)
+
+    async def _resume() -> None:
+        try:
+            record = await orchestrator.resume(run_id)
+        except KeyError as exc:
+            typer.echo(f"Run `{run_id}` not found in `{runs_dir}`.", err=True)
+            raise typer.Exit(code=1) from exc
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
+        typer.echo(f"Resumed as new run `{record.id}` (preserving completed nodes from `{run_id}`).")
+        completed = await orchestrator.wait(record.id, timeout=None)
+        _echo_run_result(completed, output=output, run_dir=_run_dir_for_record(store, record.id))
+        raise typer.Exit(code=0 if _status_value(completed.status) == "completed" else 1)
+
+    asyncio.run(_resume())
+
+
+@app.command()
 def evolve(
     run_id: str,
     node: list[str] = typer.Option(..., "--node", "-n", help="Source node ids to harvest traces from."),

--- a/agentflow/orchestrator.py
+++ b/agentflow/orchestrator.py
@@ -1166,14 +1166,21 @@ class Orchestrator:
                     remaining.remove(node_id)
                     await self._publish(run_id, "node_skipped", node_id=node_id, reason="fail_fast")
 
-            # Collect nodes involved in cycles (both targets and tail nodes)
+            # Collect ALL nodes involved in cycles — endpoints AND nodes between them.
+            # Without this, nodes between restart target and tail (e.g. workers between
+            # orchestrator and wave_review) get eagerly skipped when orchestrator
+            # fails on attempt 1, even though it may succeed on retry.
             cycle_nodes: set[str] = set()
             cycle_tail_nodes: set[str] = set()
             for n in pipeline.nodes:
                 if n.on_failure_restart:
-                    cycle_tail_nodes.add(n.id)  # tail node (has the back-edge)
+                    cycle_tail_nodes.add(n.id)
                     cycle_nodes.add(n.id)
-                    cycle_nodes.update(n.on_failure_restart)  # restart targets
+                    cycle_nodes.update(n.on_failure_restart)
+                    # Include all nodes between restart targets and this tail
+                    for target_id in n.on_failure_restart:
+                        for mid_id in self._nodes_between(node_map, target_id, n.id):
+                            cycle_nodes.add(mid_id)
             # Nodes that depend on a cycle tail should not be eagerly
             # skipped — the tail may succeed on a future iteration.
             # But once the cycle is exhausted, allow normal blocking.

--- a/agentflow/orchestrator.py
+++ b/agentflow/orchestrator.py
@@ -582,6 +582,88 @@ class Orchestrator:
         record = self.store.get_run(run_id)
         return await self.submit(record.pipeline)
 
+    async def resume(self, run_id: str) -> RunRecord:
+        """Resume a failed/cancelled run, preserving completed node results.
+
+        Creates a new run that copies completed node outputs and scratchboard
+        from the original run. Failed/cancelled/skipped nodes are reset to
+        pending so the pipeline continues from the point of failure.
+
+        Returns the new queued ``RunRecord``.
+        """
+        import shutil
+
+        old_record = self.store.get_run(run_id)
+        if old_record.status not in {RunStatus.FAILED, RunStatus.CANCELLED}:
+            raise ValueError(
+                f"Can only resume failed or cancelled runs, but run `{run_id}` has status `{old_record.status.value}`"
+            )
+
+        pipeline = old_record.pipeline
+        new_run_id = self.store.new_run_id()
+
+        # Build node results: completed nodes keep their results; others reset to pending
+        nodes: dict[str, NodeResult] = {}
+        for node in pipeline.nodes:
+            old_node = old_record.nodes.get(node.id)
+            if old_node is not None and old_node.status == NodeStatus.COMPLETED:
+                # Preserve the completed node result as-is
+                nodes[node.id] = old_node.model_copy()
+            else:
+                nodes[node.id] = NodeResult(node_id=node.id, status=NodeStatus.PENDING)
+
+        new_run = RunRecord(
+            id=new_run_id,
+            status=RunStatus.QUEUED,
+            pipeline=pipeline,
+            nodes=nodes,
+        )
+
+        self._cancel_flags[new_run_id] = threading.Event()
+        self._run_finished[new_run_id] = threading.Event()
+        self._node_cancel_flags[new_run_id] = set()
+        self._pending_node_reruns[new_run_id] = set()
+        await self.store.create_run(new_run)
+
+        # Copy scratchboard from old run if it exists
+        old_run_dir = self.store.run_dir(run_id)
+        new_run_dir = self.store.run_dir(new_run_id)
+        from agentflow.scratchboard import SCRATCHBOARD_FILENAME
+        old_sb = old_run_dir / SCRATCHBOARD_FILENAME
+        if old_sb.exists():
+            shutil.copy2(str(old_sb), str(new_run_dir / SCRATCHBOARD_FILENAME))
+
+        # Copy artifacts for completed nodes
+        old_artifacts = old_run_dir / "artifacts"
+        new_artifacts = new_run_dir / "artifacts"
+        for node_id, node_result in nodes.items():
+            if node_result.status == NodeStatus.COMPLETED:
+                src = old_artifacts / node_id
+                if src.is_dir():
+                    dst = new_artifacts / node_id
+                    dst.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(str(src), str(dst), dirs_exist_ok=True)
+
+        await self._publish(new_run_id, "run_queued", pipeline=pipeline.model_dump(mode="json"),
+                            resumed_from=run_id)
+
+        def _background() -> None:
+            acquired = False
+            try:
+                while not acquired:
+                    if self._should_cancel(new_run_id):
+                        asyncio.run(self._finalize_cancelled_queue_run(new_run_id))
+                        return
+                    acquired = self._run_slots.acquire(timeout=0.1)
+                asyncio.run(self.run(new_run_id))
+            finally:
+                if acquired:
+                    self._run_slots.release()
+                self._run_finished[new_run_id].set()
+
+        threading.Thread(target=_background, name=f"agentflow-{new_run_id}", daemon=True).start()
+        return new_run
+
     def _should_cancel(self, run_id: str) -> bool:
         if self._cancel_flags.get(run_id, threading.Event()).is_set():
             return True
@@ -847,6 +929,8 @@ class Orchestrator:
                         id=execution_node.id, agent=execution_node.agent, prompt=execution_node.prompt,
                         target=wt_target, timeout_seconds=execution_node.timeout_seconds,
                         retries=execution_node.retries, retry_backoff_seconds=execution_node.retry_backoff_seconds,
+                        retry_backoff_max_seconds=execution_node.retry_backoff_max_seconds,
+                        retry_backoff_strategy=execution_node.retry_backoff_strategy,
                         success_criteria=execution_node.success_criteria, tools=execution_node.tools,
                         model=execution_node.model, capture=execution_node.capture, env=execution_node.env,
                         extra_args=execution_node.extra_args, provider=execution_node.provider,
@@ -1040,7 +1124,14 @@ class Orchestrator:
                 success_details=result.success_details,
             )
             if attempt_number <= node.retries:
-                await asyncio.sleep(max(node.retry_backoff_seconds, 0.0) * attempt_number)
+                if getattr(node, "retry_backoff_strategy", "exponential") == "exponential":
+                    delay = min(
+                        node.retry_backoff_seconds * (2 ** (attempt_number - 1)),
+                        getattr(node, "retry_backoff_max_seconds", 300.0),
+                    )
+                else:
+                    delay = node.retry_backoff_seconds * attempt_number
+                await asyncio.sleep(max(delay, 0.0))
                 continue
             break
 
@@ -1120,7 +1211,11 @@ class Orchestrator:
 
         # Pre-register shared resource counts so instances survive between sequential nodes
         self._register_shared_resources(pipeline)
-        remaining = set(node_map)
+        # Exclude nodes already in a terminal state (e.g. completed from a resumed run)
+        remaining = {
+            node_id for node_id in node_map
+            if record.nodes[node_id].status not in {NodeStatus.COMPLETED}
+        }
         in_progress: dict[str, asyncio.Task[_NodeExecutionOutcome]] = {}
         semaphore = asyncio.Semaphore(pipeline.concurrency)
         loop = asyncio.get_running_loop()

--- a/agentflow/runners/local.py
+++ b/agentflow/runners/local.py
@@ -287,6 +287,8 @@ class LocalRunner(Runner):
             process.stdin.write(prepared.stdin.encode("utf-8"))
             await process.stdin.drain()
             process.stdin.close()
+        elif process.stdin is not None:
+            process.stdin.close()
 
         stdout_lines: list[str] = []
         stderr_lines: list[str] = []

--- a/agentflow/specs.py
+++ b/agentflow/specs.py
@@ -776,6 +776,8 @@ class NodeSpec(BaseModel):
     success_criteria: list[SuccessCriterion] = Field(default_factory=list)
     retries: int = Field(default=0, ge=0)
     retry_backoff_seconds: float = Field(default=1.0, ge=0.0)
+    retry_backoff_max_seconds: float = Field(default=300.0, ge=0.0)
+    retry_backoff_strategy: Literal["linear", "exponential"] = "exponential"
     schedule: PeriodicScheduleSpec | None = None
     fanout_group: str | None = Field(default=None, exclude=True)
     fanout_member: dict[str, Any] | None = Field(default=None, exclude=True)


### PR DESCRIPTION
## Summary
- **Exponential backoff with cap**: Replaces linear retry backoff with exponential (`base * 2^(attempt-1)`) capped at a configurable max (default 5 min). New `NodeSpec` fields: `retry_backoff_strategy` ("exponential" | "linear") and `retry_backoff_max_seconds`.
- **`agentflow resume <run-id>`**: New CLI command that creates a new run from a failed/cancelled run, preserving completed nodes and scratchboard state. Failed/cancelled/skipped nodes are reset to pending.

## Motivation
When API credits run out (e.g. 5-hour Claude outage), linear backoff with 1 retry is insufficient. Exponential backoff with higher retry counts lets nodes survive moderate outages. For longer outages, `resume` allows picking up where a run left off without re-executing completed nodes.

## Test plan
- [x] All existing retry tests pass (2/2)
- [x] All validation/DSL tests pass (77/77)
- [x] 2 pre-existing test failures on main (bash startup file detection) confirmed unrelated