### PR TITLE
fix: harden web API pipeline loading and request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,22 @@ agentflow inspect pipeline.py       # show expanded graph
 agentflow validate pipeline.py      # check without running
 agentflow templates                  # list starter templates
 agentflow init > pipeline.py        # scaffold a starter
+agentflow serve                     # start the local web UI and API on 127.0.0.1:8000
 ```
 
+## Web UI and API safety
+
+`agentflow serve` binds to `127.0.0.1` by default.
+
+The web API only accepts `application/json` requests for `/api/runs` and `/api/runs/validate`, and `pipeline_path` is disabled on those endpoints by default. This prevents the browser-facing control plane from executing arbitrary local `.py` pipeline files just by referencing a path.
+
+If you intentionally want the web API to load pipelines from filesystem paths in a trusted local environment, opt in explicitly:
+
+```bash
+AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 agentflow serve
+```
+
+That opt-in is meant for trusted operator-controlled workflows only.
 
 ## Acknowledgements
 

--- a/agentflow/app.py
+++ b/agentflow/app.py
@@ -24,6 +24,16 @@ from agentflow.store import RunStore
 _TERMINAL_RUN_STATUSES = {"completed", "failed", "cancelled"}
 
 
+def _api_pipeline_path_enabled() -> bool:
+    return os.getenv("AGENTFLOW_API_ALLOW_PIPELINE_PATH", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _require_json_request(request: Request) -> None:
+    content_type = request.headers.get("content-type", "")
+    if "application/json" not in content_type.lower():
+        raise HTTPException(status_code=415, detail="application/json content type required")
+
+
 @lru_cache(maxsize=1)
 def _load_default_web_example() -> str:
     example_path = bundled_template_path("pipeline")
@@ -45,13 +55,15 @@ def _load_default_web_example() -> str:
     return result.stdout.strip()
 
 
-def _parse_pipeline_payload(payload: dict[str, Any]) -> PipelineSpec:
+def _parse_pipeline_payload(payload: dict[str, Any], *, allow_pipeline_path: bool = True) -> PipelineSpec:
     try:
         if not isinstance(payload, dict):
             raise ValueError("request body must be a JSON object")
 
         pipeline_path = payload.get("pipeline_path")
         if isinstance(pipeline_path, str) and pipeline_path.strip():
+            if not allow_pipeline_path:
+                raise HTTPException(status_code=403, detail="pipeline_path is disabled for the web API by default")
             return load_pipeline_from_path(pipeline_path)
 
         base_dir = payload.get("base_dir")
@@ -100,14 +112,16 @@ def create_app(*, store: RunStore | None = None, orchestrator: Orchestrator | No
 
     @app.post("/api/runs/validate")
     async def validate_run(request: Request) -> JSONResponse:
+        _require_json_request(request)
         payload = await request.json()
-        pipeline = _parse_pipeline_payload(payload)
+        pipeline = _parse_pipeline_payload(payload, allow_pipeline_path=_api_pipeline_path_enabled())
         return JSONResponse({"ok": True, "pipeline": pipeline.model_dump(mode="json")})
 
     @app.post("/api/runs")
     async def create_run(request: Request) -> JSONResponse:
+        _require_json_request(request)
         payload = await request.json()
-        pipeline = _parse_pipeline_payload(payload)
+        pipeline = _parse_pipeline_payload(payload, allow_pipeline_path=_api_pipeline_path_enabled())
         run = await app.state.orchestrator.submit(pipeline)
         return JSONResponse(run.model_dump(mode="json"))
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,6 +61,30 @@ agentflow run examples/pipeline.yaml
 
 On a terminal, `run` and `inspect` default to a compact summary. When stdout is redirected, they fall back to JSON-oriented output. You can always force a format with `--output`.
 
+## Serve the local web UI
+
+Start the local web UI and API:
+
+```bash
+agentflow serve
+```
+
+Defaults:
+- host: `127.0.0.1`
+- port: `8000`
+
+The web API only accepts `application/json` for `/api/runs` and `/api/runs/validate`.
+
+For safety, the browser-facing API also disables `pipeline_path` by default, so a request cannot cause AgentFlow to execute a local `.py` pipeline file just by naming its path.
+
+If you intentionally want to allow filesystem path loading from the local web API in a trusted environment, opt in explicitly:
+
+```bash
+AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 agentflow serve
+```
+
+Treat that override as a trusted operator-only setting.
+
 ## Tuned Agents And Evolution
 
 PR #11 adds a local tuned-agent workflow:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,7 +144,27 @@ def test_api_run_resolves_inline_pipeline_relative_to_explicit_base_dir(tmp_path
     asyncio.run(orchestrator.wait(body["id"], timeout=5))
 
 
-def test_api_validate_supports_pipeline_path_payload(tmp_path):
+def test_api_validate_rejects_pipeline_path_payload_by_default(tmp_path):
+    orchestrator = make_orchestrator(tmp_path)
+    app = create_app(store=orchestrator.store, orchestrator=orchestrator)
+    client = TestClient(app)
+
+    pipeline_dir = tmp_path / "pipelines"
+    pipeline_dir.mkdir()
+    pipeline_path = pipeline_dir / "api.json"
+    pipeline_path.write_text(
+        json.dumps({"name": "pipeline-path", "working_dir": ".", "nodes": [{"id": "alpha", "agent": "codex", "prompt": "hi", "target": {"kind": "local", "cwd": "task"}}]}),
+        encoding="utf-8",
+    )
+
+    response = client.post("/api/runs/validate", json={"pipeline_path": str(pipeline_path)})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "pipeline_path is disabled for the web API by default"
+
+
+def test_api_validate_supports_pipeline_path_payload_when_explicitly_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTFLOW_API_ALLOW_PIPELINE_PATH", "1")
     orchestrator = make_orchestrator(tmp_path)
     app = create_app(store=orchestrator.store, orchestrator=orchestrator)
     client = TestClient(app)
@@ -163,6 +183,22 @@ def test_api_validate_supports_pipeline_path_payload(tmp_path):
     payload = response.json()["pipeline"]
     assert payload["working_dir"] == str(pipeline_dir.resolve())
     assert payload["nodes"][0]["target"]["cwd"] == str((pipeline_dir / "task").resolve())
+
+
+
+def test_api_rejects_non_json_content_type(tmp_path):
+    orchestrator = make_orchestrator(tmp_path)
+    app = create_app(store=orchestrator.store, orchestrator=orchestrator)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/runs/validate",
+        data=json.dumps({"pipeline": {"name": "ok", "working_dir": str(tmp_path), "nodes": [{"id": "alpha", "agent": "codex", "prompt": "hi"}]}}),
+        headers={"Content-Type": "text/plain"},
+    )
+
+    assert response.status_code == 415
+    assert response.json()["detail"] == "application/json content type required"
 
 
 def test_api_supports_cancel_and_rerun(tmp_path):


### PR DESCRIPTION
## Summary
This PR hardens the local web UI/API control plane so browser-reachable requests cannot use the web API to execute arbitrary local pipeline files by path.
- requires `application/json` on `/api/runs` and `/api/runs/validate`
- disables `pipeline_path` on those web API endpoints by default
- adds an explicit trusted-operator opt-in via `AGENTFLOW_API_ALLOW_PIPELINE_PATH=1`
- adds focused regression coverage for the new default-deny behavior and opt-in path

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Web API accepted `pipeline_path` and loaded local `.py` pipeline files | browser-reachable local control-plane request could trigger execution of a local Python pipeline file | High |
| Web API accepted non-JSON content types for run creation/validation | widened browser-driven attack surface for localhost control-plane abuse | Medium |

## Before this PR
- `/api/runs` and `/api/runs/validate` accepted requests that supplied `pipeline_path`
- those routes could call `load_pipeline_from_path(...)`, which executes `.py` pipeline files during loading
- the web API did not enforce `application/json` on these routes
- there was no regression coverage preventing future reintroduction of this path through the browser-facing API

## After this PR
- `/api/runs` and `/api/runs/validate` now reject non-JSON requests with HTTP 415
- `pipeline_path` is disabled for the web API by default and rejected with HTTP 403
- trusted local operators can re-enable path-based loading explicitly with `AGENTFLOW_API_ALLOW_PIPELINE_PATH=1`
- tests now lock in default-deny behavior, the explicit opt-in path, and JSON-only request handling

## Explicit operator choice
Secure default:
```bash
agentflow serve
```
Behavior:
- binds locally as before
- rejects non-JSON requests on `/api/runs` and `/api/runs/validate`
- rejects `pipeline_path` on those browser-facing endpoints

Explicit trusted opt-in:
```bash
AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 agentflow serve
```
Behavior:
- preserves trusted local operator workflows that intentionally load pipelines from filesystem paths through the web API
- keeps that capability behind an explicit environment-level decision instead of enabling it implicitly for every browser-reachable request

## Why this matters
The web UI/API is a local control plane, not an untrusted code-loading surface. Before this patch, a request that could reach the browser-facing API could ask AgentFlow to load a local pipeline file by path, including a `.py` pipeline that executes during loading. Requiring JSON and default-disabling `pipeline_path` restores the intended trust boundary for the web API while keeping an explicit opt-in for trusted local workflows.

## Attack flow
```text
browser-reachable request with pipeline_path
    -> /api/runs or /api/runs/validate
        -> load_pipeline_from_path(...)
            -> local .py pipeline execution during load
```

## Affected code
| Issue | Files |
|-------|-------|
| Default-disable `pipeline_path` for web API requests | `agentflow/app.py`, `tests/test_api.py` |
| Enforce JSON-only request handling on web API routes | `agentflow/app.py`, `tests/test_api.py` |
| Document secure default and explicit opt-in | `README.md`, `docs/cli.md` |

## Root cause
Issue 1: web API path-based pipeline loading
- the web API accepted a `pipeline_path` field and passed it into `load_pipeline_from_path(...)`
- that trusted a browser-facing control-plane request with a filesystem-loading primitive that can execute local `.py` pipeline files

Issue 2: missing JSON content-type enforcement
- the web API accepted non-JSON content types on run creation and validation routes
- that unnecessarily broadened the set of request shapes a browser could use to reach the vulnerable control plane

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Web API accepted `pipeline_path` and loaded local `.py` pipeline files | 7.3 High | `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H` |
| Web API accepted non-JSON content types for run creation/validation | 4.3 Medium | `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N` |

Rationale:
- the primary issue is a local/browser-reachable control-plane boundary break that can lead to unintended code execution from a local pipeline file path
- the content-type issue is lower severity on its own, but materially weakens the web API boundary and helps browser-driven abuse of localhost surfaces

## Safe reproduction steps
### 1. Default-denied `pipeline_path` on the web API
1. Create a temporary local pipeline file.
2. Send `POST /api/runs/validate` with JSON body `{ "pipeline_path": "/path/to/pipeline" }`.
3. Observe HTTP 403 with `pipeline_path is disabled for the web API by default`.

### 2. JSON-only enforcement
1. Send `POST /api/runs/validate` with a non-JSON `Content-Type` such as `text/plain`.
2. Use an otherwise valid JSON payload body.
3. Observe HTTP 415 with `application/json content type required`.

### 3. Explicit trusted opt-in
1. Start the server with `AGENTFLOW_API_ALLOW_PIPELINE_PATH=1`.
2. Send `POST /api/runs/validate` with JSON body containing a valid local `pipeline_path`.
3. Observe that the route accepts the path-based trusted local workflow again.

## Expected vulnerable behavior
- A browser-facing request should never have been able to drive local filesystem pipeline loading by path on the web API.
- Before this patch, the web API accepted that request shape and did not require JSON-only handling on these routes.

## Changes in this PR
- add `_require_json_request(...)` and apply it to `/api/runs` and `/api/runs/validate`
- add `_api_pipeline_path_enabled()` as an explicit opt-in gate
- change `_parse_pipeline_payload(...)` so web API callers reject `pipeline_path` by default with HTTP 403
- add focused regression tests for default-denied `pipeline_path`, explicit opt-in enablement, and non-JSON rejection
- document the secure default and explicit opt-in behavior in `README.md` and `docs/cli.md`

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Runtime guardrails | `agentflow/app.py` | added JSON-only enforcement and default-denied `pipeline_path` gate for web API routes |
| Regression tests | `tests/test_api.py` | added coverage for 403 default deny, 415 non-JSON rejection, and explicit opt-in success |
| Documentation | `README.md`, `docs/cli.md` | documented secure default behavior and explicit trusted opt-in |

## Maintainer impact
- patch scope is narrow and limited to the browser-facing web API entrypoint plus docs/tests
- CLI and trusted local path-based workflows remain available through an explicit opt-in instead of silent default exposure
- the new control point is centralized in `agentflow/app.py`, which should make future refactors easier to keep secure

## Suggested fix rationale
- the web API should treat filesystem path loading as privileged control-plane behavior, not as a default request capability
- requiring JSON on these routes is a small, durable boundary check that reduces browser-driven localhost abuse paths
- the opt-in model keeps legitimate trusted local workflows available without making the dangerous behavior the default
- the regression tests cover the vulnerable edge directly and should make accidental reintroduction obvious

## Reference patterns from other software
- GitHub Actions requires explicit approval before running untrusted fork workflows; this PR follows the same secure-by-default principle for a privileged control-plane path
- Kubernetes RBAC and Keycloak fine-grained admin permissions similarly separate ordinary runtime access from explicit privileged actions

## Type of change
- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `python -m pytest tests/test_api.py -q`
- [x] manually reviewed the route-to-loader code path in `agentflow/app.py` and `agentflow/loader.py`
- [ ] full repository test suite

Executed with:
- `source /Users/lennon/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_api.py -q`
- `git diff -- README.md agentflow/app.py docs/cli.md tests/test_api.py`

Not run:
- the full repository test suite is not claimed green in this PR body; this PR only claims the focused API regression coverage above

## Disclosure notes
- claims in this PR are bounded to the reviewed web API entrypoints and reproduced local validation path
- the repository does not currently include a `SECURITY.md`
- no unrelated source files were changed outside the web API guard, docs, and focused tests
