### PR TITLE
[security] fix: contain run artifact paths

### DIFF
--- a/agentflow/app.py
+++ b/agentflow/app.py
@@ -163,6 +163,8 @@ def create_app(*, store: RunStore | None = None, orchestrator: Orchestrator | No
     async def get_artifact(run_id: str, node_id: str, name: str) -> PlainTextResponse:
         try:
             content = app.state.store.read_artifact_text(run_id, node_id, name)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="invalid artifact path") from exc
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail="artifact not found") from exc
         return PlainTextResponse(content)

--- a/agentflow/store.py
+++ b/agentflow/store.py
@@ -52,6 +52,7 @@ class RunStore:
     async def create_run(self, record: RunRecord | None = None) -> RunRecord:
         if record is None:
             raise ValueError("create_run requires a RunRecord")
+        _safe_path_segment(record.id, "run_id")
         self._runs[record.id] = record
         await self.persist_run(record.id)
         return record

--- a/agentflow/store.py
+++ b/agentflow/store.py
@@ -4,13 +4,23 @@ import json
 import queue
 import threading
 from collections import defaultdict
-from pathlib import Path
+from pathlib import Path, PurePath
 from uuid import uuid4
 
 from pydantic import ValidationError
 
 from agentflow.specs import RunEvent, RunRecord
 from agentflow.utils import ensure_dir
+
+
+def _safe_path_segment(value: str, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"invalid {label} path segment")
+    if value in {".", ".."} or "/" in value or "\\" in value:
+        raise ValueError(f"invalid {label} path segment")
+    if PurePath(value).name != value:
+        raise ValueError(f"invalid {label} path segment")
+    return value
 
 
 class RunStore:
@@ -50,13 +60,13 @@ class RunStore:
         return uuid4().hex
 
     def run_dir(self, run_id: str) -> Path:
-        return ensure_dir(self.base_dir / run_id)
+        return ensure_dir(self.base_dir / _safe_path_segment(run_id, "run_id"))
 
     def node_artifact_dir(self, run_id: str, node_id: str) -> Path:
-        return ensure_dir(self.run_dir(run_id) / "artifacts" / node_id)
+        return ensure_dir(self.run_dir(run_id) / "artifacts" / _safe_path_segment(node_id, "node_id"))
 
     def artifact_path(self, run_id: str, node_id: str, name: str) -> Path:
-        return self.node_artifact_dir(run_id, node_id) / name
+        return self.node_artifact_dir(run_id, node_id) / _safe_path_segment(name, "artifact name")
 
     def cancel_request_path(self, run_id: str) -> Path:
         return self.run_dir(run_id) / "cancel.requested"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,20 @@ def test_api_rejects_artifact_path_traversal(tmp_path):
     assert outside_runs_file.status_code == 400
 
 
+async def test_store_create_run_rejects_invalid_run_id_atomically(tmp_path):
+    store = RunStore(tmp_path / "runs")
+    record = RunRecord(
+        id="../outside",
+        pipeline={"name": "p", "nodes": [{"id": "alpha", "agent": "codex", "prompt": "hi"}]},
+    )
+
+    with pytest.raises(ValueError, match="path segment"):
+        await store.create_run(record)
+
+    assert store.list_runs() == []
+    assert not (tmp_path / "outside").exists()
+
+
 async def test_store_rejects_artifact_write_path_traversal(tmp_path):
     store = RunStore(tmp_path / "runs")
     await store.create_run(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,10 +4,12 @@ import asyncio
 import json
 import os
 
+import pytest
 from fastapi.testclient import TestClient
 
 from agentflow.app import create_app
 from agentflow.orchestrator import Orchestrator
+from agentflow.specs import RunRecord
 from agentflow.store import RunStore
 from tests.test_orchestrator import make_orchestrator
 
@@ -184,6 +186,51 @@ def test_api_validate_supports_pipeline_path_payload_when_explicitly_enabled(tmp
     assert payload["working_dir"] == str(pipeline_dir.resolve())
     assert payload["nodes"][0]["target"]["cwd"] == str((pipeline_dir / "task").resolve())
 
+
+
+def test_api_rejects_artifact_path_traversal(tmp_path):
+    orchestrator = make_orchestrator(tmp_path)
+    app = create_app(store=orchestrator.store, orchestrator=orchestrator)
+    client = TestClient(app)
+
+    outside_secret = tmp_path / "secret.txt"
+    outside_secret.write_text("outside-runs-secret", encoding="utf-8")
+
+    create = client.post(
+        "/api/runs",
+        json={"pipeline": {"name": "artifact", "working_dir": str(tmp_path), "nodes": [{"id": "alpha", "agent": "codex", "prompt": "artifact output"}]}},
+    )
+    run_id = create.json()["id"]
+    asyncio.run(orchestrator.wait(run_id, timeout=5))
+
+    sibling_run_file = client.get(f"/api/runs/{run_id}/artifacts/%2E%2E/run.json")
+    assert sibling_run_file.status_code == 400
+
+    outside_runs_file = client.get("/api/runs/%2E%2E/artifacts/%2E%2E/secret.txt")
+    assert outside_runs_file.status_code == 400
+
+
+async def test_store_rejects_artifact_write_path_traversal(tmp_path):
+    store = RunStore(tmp_path / "runs")
+    await store.create_run(
+        RunRecord(
+            id="run",
+            pipeline={"name": "p", "nodes": [{"id": "alpha", "agent": "codex", "prompt": "hi"}]},
+        )
+    )
+
+    with pytest.raises(ValueError, match="path segment"):
+        await store.write_artifact_text("run", "../../outside", "output.txt", "pwned")
+    assert not (tmp_path / "outside" / "output.txt").exists()
+
+
+async def test_store_rejects_artifact_read_path_traversal(tmp_path):
+    store = RunStore(tmp_path / "runs")
+    outside_secret = tmp_path / "secret.txt"
+    outside_secret.write_text("outside-runs-secret", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="path segment"):
+        store.read_artifact_text("..", "..", "secret.txt")
 
 
 def test_api_rejects_non_json_content_type(tmp_path):


### PR DESCRIPTION
## Summary

This PR hardens AgentFlow's run artifact filesystem boundary.

- Rejects traversal-style `run_id`, `node_id`, and artifact name path segments before reading or writing artifacts.
- Returns a bounded `400` response for invalid artifact API paths instead of resolving attacker-controlled `..` segments.
- Adds regression coverage for API reads and store write/read sinks.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Artifact API path traversal | Untrusted path parameters could read files outside a node's artifact directory and, through store write sinks, write artifacts outside the intended run tree | High |

## Before this PR

- `/api/runs/{run_id}/artifacts/{node_id}/{name}` passed path parameters directly into `RunStore.read_artifact_text(...)`.
- `RunStore` built filesystem paths with raw `run_id`, `node_id`, and artifact `name` values.
- URL-encoded `..` path segments could escape `artifacts/<node_id>/` and reach sibling files such as `run.json` or files outside the configured runs directory.
- Artifact write helpers used the same path construction pattern.

## After this PR

- `RunStore` validates each path component as a single safe segment before constructing filesystem paths.
- Empty values, `.`, `..`, `/`, and `\` are rejected.
- The artifact API maps invalid path segments to `400 invalid artifact path`.
- Regression tests cover traversal attempts through both the public API and store read/write helpers.

## Why this matters

Run artifacts can contain prompts, stdout/stderr logs, launch metadata, result data, and other local execution details. A browser/API caller should only be able to read the requested node artifact, not escape into sibling run metadata or adjacent files.

## Attack flow

```text
encoded ../ path segment in artifact URL
    -> FastAPI path parameters
        -> RunStore path concatenation
            -> read file outside intended artifact directory
```

## Affected code

| Issue | Files |
|-------|-------|
| Artifact path traversal | `agentflow/app.py`, `agentflow/store.py`, `tests/test_api.py` |

## Root cause

Artifact path traversal:
- Direct cause: artifact path components were concatenated into `Path` objects without checking that each component was a safe basename.
- Boundary failure: public API path parameters were treated as trusted filesystem path components.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Artifact API path traversal | 7.5 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N` |

Rationale:
- The public web API can be reached without application-layer authentication in the current app model, and successful traversal can disclose local run metadata or adjacent files readable by the AgentFlow process.

## Safe reproduction steps

1. Start an affected AgentFlow web API with a writable runs directory.
2. Create or identify a run ID.
3. Request an encoded traversal path such as:
   ```text
   GET /api/runs/<run_id>/artifacts/%2E%2E/run.json
   ```
4. Observe the pre-patch server returning the run metadata file instead of rejecting the path.
5. Repeat after this PR and observe `400 invalid artifact path`.

## Expected vulnerable behavior

- Pre-patch: encoded `..` segments could escape the intended artifact directory.
- Post-patch: traversal-like path segments are rejected before filesystem access.

## Changes in this PR

- Adds `_safe_path_segment(...)` in `RunStore`.
- Applies segment validation to `run_dir`, `node_artifact_dir`, and `artifact_path`.
- Handles invalid artifact API paths with HTTP 400.
- Adds tests for API traversal rejection and store-level read/write traversal rejection.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Store hardening | `agentflow/store.py` | Validate path components before building run/artifact paths |
| API hardening | `agentflow/app.py` | Return a bounded client error for invalid artifact paths |
| Tests | `tests/test_api.py` | Add traversal regression tests for API and store sinks |

## Maintainer impact

- The patch is narrow and only affects path component validation for run/artifact storage helpers.
- Legitimate generated run IDs, node IDs, and fixed artifact filenames continue to work.
- Invalid traversal-style paths fail before filesystem access.

## Fix rationale

Filesystem boundaries should be enforced at the storage helper layer, not only at the route layer, because the same helper is used by both read and write paths. Validating each component as a basename gives a simple invariant that is hard to bypass during future refactors.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Targeted traversal regression tests pass.
- [x] API/store regression tests pass.
- [ ] Full test suite completed locally.

Executed with:

- `/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest tests/test_api.py::test_api_rejects_artifact_path_traversal tests/test_api.py::test_store_rejects_artifact_write_path_traversal tests/test_api.py::test_store_rejects_artifact_read_path_traversal -q`
- `/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest tests/test_api.py tests/test_store_and_validation.py -q`

Full suite note:
- I also attempted `/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest -q`; it did not complete within 600s in my local environment and showed broad unrelated failures before timeout, so the focused API/store checks above are the validation for this patch.


## Disclosure notes

- This PR is bounded to artifact path containment.
- It does not include unrelated authentication or execution-policy changes.
- No unrelated files were changed.
