### PR TITLE
[security] fix: gate executable web API agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,13 +246,17 @@ agentflow serve                     # start the local web UI and API on 127.0.0.
 
 The web API only accepts `application/json` requests for `/api/runs` and `/api/runs/validate`, and `pipeline_path` is disabled on those endpoints by default. This prevents the browser-facing control plane from executing arbitrary local `.py` pipeline files just by referencing a path.
 
-If you intentionally want the web API to load pipelines from filesystem paths in a trusted local environment, opt in explicitly:
+Inline `shell` and `python` utility agents are also disabled for web API requests by default. This prevents browser/API callers from turning a submitted pipeline into direct local command execution.
+
+If you intentionally want the web API to load pipelines from filesystem paths or accept inline executable utility agents in a trusted local environment, opt in explicitly:
 
 ```bash
-AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 agentflow serve
+AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 \
+AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1 \
+agentflow serve
 ```
 
-That opt-in is meant for trusted operator-controlled workflows only.
+Those opt-ins are meant for trusted operator-controlled workflows only.
 
 ## Acknowledgements
 

--- a/agentflow/app.py
+++ b/agentflow/app.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 from agentflow.defaults import bundled_template_path
 from agentflow.loader import load_pipeline_from_data, load_pipeline_from_path, load_pipeline_from_text
 from agentflow.orchestrator import Orchestrator
-from agentflow.specs import PipelineSpec
+from agentflow.specs import AgentKind, PipelineSpec
 from agentflow.store import RunStore
 
 
@@ -26,6 +26,18 @@ _TERMINAL_RUN_STATUSES = {"completed", "failed", "cancelled"}
 
 def _api_pipeline_path_enabled() -> bool:
     return os.getenv("AGENTFLOW_API_ALLOW_PIPELINE_PATH", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _api_executable_agents_enabled() -> bool:
+    return os.getenv("AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _reject_web_api_executable_agents(pipeline: PipelineSpec) -> None:
+    if _api_executable_agents_enabled():
+        return
+    executable_agents = {AgentKind.PYTHON, AgentKind.SHELL}
+    if any(node.agent in executable_agents for node in pipeline.nodes):
+        raise HTTPException(status_code=403, detail="executable agents are disabled for the web API by default")
 
 
 def _require_json_request(request: Request) -> None:
@@ -115,6 +127,7 @@ def create_app(*, store: RunStore | None = None, orchestrator: Orchestrator | No
         _require_json_request(request)
         payload = await request.json()
         pipeline = _parse_pipeline_payload(payload, allow_pipeline_path=_api_pipeline_path_enabled())
+        _reject_web_api_executable_agents(pipeline)
         return JSONResponse({"ok": True, "pipeline": pipeline.model_dump(mode="json")})
 
     @app.post("/api/runs")
@@ -122,6 +135,7 @@ def create_app(*, store: RunStore | None = None, orchestrator: Orchestrator | No
         _require_json_request(request)
         payload = await request.json()
         pipeline = _parse_pipeline_payload(payload, allow_pipeline_path=_api_pipeline_path_enabled())
+        _reject_web_api_executable_agents(pipeline)
         run = await app.state.orchestrator.submit(pipeline)
         return JSONResponse(run.model_dump(mode="json"))
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,13 +77,17 @@ The web API only accepts `application/json` for `/api/runs` and `/api/runs/valid
 
 For safety, the browser-facing API also disables `pipeline_path` by default, so a request cannot cause AgentFlow to execute a local `.py` pipeline file just by naming its path.
 
-If you intentionally want to allow filesystem path loading from the local web API in a trusted environment, opt in explicitly:
+Inline `shell` and `python` utility agents are also disabled for web API requests by default, so a submitted pipeline cannot directly become local command execution through the browser/API control plane.
+
+If you intentionally want to allow filesystem path loading or inline executable utility agents from the local web API in a trusted environment, opt in explicitly:
 
 ```bash
-AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 agentflow serve
+AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 \
+AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1 \
+agentflow serve
 ```
 
-Treat that override as a trusted operator-only setting.
+Treat those overrides as trusted operator-only settings.
 
 ## Tuned Agents And Evolution
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,7 +186,8 @@ def test_api_validate_supports_pipeline_path_payload_when_explicitly_enabled(tmp
 
 
 
-def test_api_rejects_inline_executable_agents_by_default(tmp_path):
+def test_api_rejects_inline_executable_agents_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS", raising=False)
     orchestrator = make_orchestrator(tmp_path)
     app = create_app(store=orchestrator.store, orchestrator=orchestrator)
     client = TestClient(app)
@@ -208,7 +209,7 @@ def test_api_rejects_inline_executable_agents_by_default(tmp_path):
     assert create.json()["detail"] == "executable agents are disabled for the web API by default"
 
 
-async def test_api_allows_inline_executable_agents_when_explicitly_enabled(tmp_path, monkeypatch):
+def test_api_allows_inline_executable_agents_when_explicitly_enabled(tmp_path, monkeypatch):
     monkeypatch.setenv("AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS", "1")
     orchestrator = make_orchestrator(tmp_path)
     app = create_app(store=orchestrator.store, orchestrator=orchestrator)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,6 +186,50 @@ def test_api_validate_supports_pipeline_path_payload_when_explicitly_enabled(tmp
 
 
 
+def test_api_rejects_inline_executable_agents_by_default(tmp_path):
+    orchestrator = make_orchestrator(tmp_path)
+    app = create_app(store=orchestrator.store, orchestrator=orchestrator)
+    client = TestClient(app)
+
+    payload = {
+        "pipeline": {
+            "name": "shell-rce",
+            "working_dir": str(tmp_path),
+            "nodes": [{"id": "shell", "agent": "shell", "prompt": "echo unsafe"}],
+        }
+    }
+
+    validate = client.post("/api/runs/validate", json=payload)
+    assert validate.status_code == 403
+    assert validate.json()["detail"] == "executable agents are disabled for the web API by default"
+
+    create = client.post("/api/runs", json=payload)
+    assert create.status_code == 403
+    assert create.json()["detail"] == "executable agents are disabled for the web API by default"
+
+
+async def test_api_allows_inline_executable_agents_when_explicitly_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS", "1")
+    orchestrator = make_orchestrator(tmp_path)
+    app = create_app(store=orchestrator.store, orchestrator=orchestrator)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/runs/validate",
+        json={
+            "pipeline": {
+                "name": "python-opt-in",
+                "working_dir": str(tmp_path),
+                "nodes": [{"id": "py", "agent": "python", "prompt": "print('trusted')"}],
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["pipeline"]["nodes"][0]["agent"] == "python"
+
+
+
 def test_api_rejects_non_json_content_type(tmp_path):
     orchestrator = make_orchestrator(tmp_path)
     app = create_app(store=orchestrator.store, orchestrator=orchestrator)


### PR DESCRIPTION
## Summary

This PR hardens AgentFlow's browser-facing web API against direct executable utility-agent submission.

- Disables inline `shell` and `python` utility agents for web API requests by default.
- Keeps trusted local/operator workflows available through an explicit `AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1` opt-in.
- Adds regression tests for both the secure default and trusted opt-in behavior.
- Documents the new web API safety setting alongside the existing `pipeline_path` opt-in.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Inline executable web API agents | A caller that can reach the web API could submit a pipeline whose `shell` or `python` node executes local code as the AgentFlow process user | Critical when exposed; High/Critical conditional for localhost browser-origin abuse |

## Before this PR

- PR #18 disabled `pipeline_path` by default for the web API, preventing path-based `.py` pipeline loading.
- The inline JSON pipeline path still accepted built-in `shell` and `python` nodes.
- Those utility agents execute the submitted prompt via `bash -c` or `python3 -c`.
- The web API did not distinguish trusted local/operator pipeline execution from browser/API-submitted inline executable utility agents.

## After this PR

- `/api/runs` and `/api/runs/validate` reject inline `shell` and `python` nodes by default.
- Trusted operators can explicitly restore the behavior with:
  ```bash
  AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1 agentflow serve
  ```
- Regression tests lock in both default-deny and explicit opt-in behavior.
- README and CLI docs describe the control-plane boundary and trusted-operator override.

## Explicit operator choice

Secure default:

```bash
agentflow serve
```

Behavior:
- `pipeline_path` is disabled unless `AGENTFLOW_API_ALLOW_PIPELINE_PATH=1` is set.
- Inline `shell` and `python` utility agents are disabled unless `AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1` is set.

Trusted local opt-in:

```bash
AGENTFLOW_API_ALLOW_PIPELINE_PATH=1 \
AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1 \
agentflow serve
```

Behavior:
- A trusted operator can intentionally allow filesystem pipeline loading and inline executable utility agents from the local web API.
- The override is intended for operator-controlled local workflows, not untrusted browser/API callers.

## Why this matters

The web API is a control plane for launching local agent work. Inline executable utility agents are useful in trusted pipelines, but they are too powerful to accept from browser/API submissions by default because the submitted prompt becomes local process execution.

## Attack flow

```text
POST /api/runs with inline pipeline JSON
    -> node uses agent: shell or agent: python
        -> prompt becomes bash/python code
            -> command executes as the AgentFlow server user
```

## Affected code

| Issue | Files |
|-------|-------|
| Inline executable web API agents | `agentflow/app.py`, `tests/test_api.py`, `README.md`, `docs/cli.md` |

## Root cause

Inline executable web API agents:
- Direct cause: the web API accepted inline pipeline JSON containing `shell` and `python` utility agents without an API-specific execution policy.
- Boundary failure: trusted local pipeline execution semantics were reused for browser/API-submitted pipelines.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Inline executable web API agents | 9.8 Critical when network-exposed | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` |

Rationale:
- If the web API is reachable by an untrusted network client, submitting a `shell` or `python` node gives direct local code execution as the AgentFlow process user.
- For strictly localhost-only deployments, practical exploitability depends on local/browser-origin reachability such as DNS rebinding or another local request source; the fix still keeps the dangerous primitive behind an explicit operator opt-in.

## Safe reproduction steps

1. Start an affected AgentFlow web API.
2. Submit an inline pipeline to `POST /api/runs`:
   ```json
   {
     "pipeline": {
       "name": "rce",
       "working_dir": "/tmp/agentflow-poc",
       "nodes": [
         {
           "id": "s",
           "agent": "shell",
           "prompt": "id > /tmp/agentflow-poc/pwned.txt; echo SHELL-OK"
         }
       ]
     }
   }
   ```
3. Observe the pre-patch server accepting the run and executing the shell prompt.
4. Repeat after this PR without `AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1`.
5. Observe `403 executable agents are disabled for the web API by default`.
6. Set `AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS=1` in a trusted local environment and confirm validation allows the executable agent again.

## Expected vulnerable behavior

- Pre-patch: a browser/API caller could submit inline `shell`/`python` nodes and trigger local execution.
- Post-patch: executable utility agents are unavailable to web API requests unless a trusted operator explicitly opts in.

## Changes in this PR

- Adds `_api_executable_agents_enabled()` for trusted operator opt-in.
- Adds `_reject_web_api_executable_agents(...)` to block `shell` and `python` nodes by default.
- Applies the guard to both `/api/runs/validate` and `/api/runs`.
- Adds regression tests for default-deny and opt-in behavior.
- Updates README and CLI docs with the new web API safety setting.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API hardening | `agentflow/app.py` | Reject executable utility agents for web API requests unless explicitly enabled |
| Tests | `tests/test_api.py` | Add default-deny and trusted opt-in regression tests |
| Documentation | `README.md`, `docs/cli.md` | Document the new `AGENTFLOW_API_ALLOW_EXECUTABLE_AGENTS` setting |

## Maintainer impact

- Existing local/CLI pipeline behavior is unchanged.
- Web API callers keep using ordinary non-executable agent nodes by default.
- Operators who intentionally need web API-submitted executable utility agents can opt in explicitly.

## Fix rationale

This mirrors the existing secure-default pattern for `pipeline_path`: powerful local execution features remain available for trusted operators, but browser/API submissions do not get them implicitly. Applying the guard after pipeline parsing keeps validation consistent across inline JSON and text payloads.

## Adjacent public context

PR #18 already fixed the related `pipeline_path` web API issue by default-denying path-based local pipeline loading. This PR addresses a distinct remaining inline pipeline path: executable utility agents submitted directly in JSON.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Targeted executable-agent regression tests pass.
- [x] API regression tests pass.
- [ ] Full test suite completed locally.

Executed with:

- `/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest tests/test_api.py::test_api_rejects_inline_executable_agents_by_default tests/test_api.py::test_api_allows_inline_executable_agents_when_explicitly_enabled -q`
- `/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest tests/test_api.py -q`

Full suite note:
- I also attempted `/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest -q`; it did not complete within 600s in my local environment and showed broad unrelated failures before timeout, so the focused API checks above are the validation for this patch.


## Disclosure notes

- Claims are bounded to inline `shell` and `python` web API submissions.
- This PR does not claim to add full web API authentication.
- No unrelated files were changed.
