### PR TITLE
specs/success: add OutputRegexCriterion

### DIFF
--- a/agentflow/specs.py
+++ b/agentflow/specs.py
@@ -484,6 +484,21 @@ class OutputContainsCriterion(BaseModel):
     case_sensitive: bool = False
 
 
+class OutputRegexCriterion(BaseModel):
+    """Regex match against the captured node output.
+
+    ``value`` is a Python ``re`` pattern. ``multiline`` enables ``re.MULTILINE``
+    so ``^``/``$`` match line boundaries (useful when checking that a status
+    line appears anywhere in the agent's reply). ``case_sensitive`` defaults
+    to ``True`` because regex authors typically express case explicitly.
+    """
+
+    kind: Literal["output_regex"] = "output_regex"
+    value: str
+    case_sensitive: bool = True
+    multiline: bool = True
+
+
 class FileExistsCriterion(BaseModel):
     kind: Literal["file_exists"] = "file_exists"
     path: str
@@ -502,7 +517,11 @@ class FileNonEmptyCriterion(BaseModel):
 
 
 SuccessCriterion = Annotated[
-    OutputContainsCriterion | FileExistsCriterion | FileContainsCriterion | FileNonEmptyCriterion,
+    OutputContainsCriterion
+    | OutputRegexCriterion
+    | FileExistsCriterion
+    | FileContainsCriterion
+    | FileNonEmptyCriterion,
     Field(discriminator="kind"),
 ]
 

--- a/agentflow/success.py
+++ b/agentflow/success.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from agentflow.specs import (
@@ -9,6 +10,7 @@ from agentflow.specs import (
     NodeResult,
     NodeSpec,
     OutputContainsCriterion,
+    OutputRegexCriterion,
 )
 
 
@@ -45,6 +47,20 @@ def evaluate_success(node: NodeSpec, result: NodeResult, working_dir: Path) -> t
             needle = criterion.value if criterion.case_sensitive else criterion.value.lower()
             ok = needle in haystack
             messages.append(f"output_contains({criterion.value!r})={ok}")
+        elif isinstance(criterion, OutputRegexCriterion):
+            flags = 0
+            if not criterion.case_sensitive:
+                flags |= re.IGNORECASE
+            if criterion.multiline:
+                flags |= re.MULTILINE
+            try:
+                ok = re.search(criterion.value, output, flags) is not None
+            except re.error as exc:
+                ok = False
+                messages.append(f"output_regex({criterion.value!r}): invalid pattern ({exc})")
+                passed = passed and ok
+                continue
+            messages.append(f"output_regex({criterion.value!r})={ok}")
         elif isinstance(criterion, FileExistsCriterion):
             ok = (working_dir / criterion.path).exists()
             messages.append(f"file_exists({criterion.path})={ok}")


### PR DESCRIPTION
## Summary

Adds an `output_regex` success criterion that matches a Python `re` pattern against captured node output. Two switches:

- `case_sensitive` (default `True`): regex authors usually express case intentionally.
- `multiline` (default `True`): so `^`/`$` anchor on line boundaries — useful when asserting that a status line appears on its own line in an agent's reply.

Existing criteria (`output_contains`, `file_*`) are unchanged. The new variant is wired into the discriminated union in `specs.SuccessCriterion` and the dispatcher in `success.evaluate_success`. Invalid regex patterns surface as a non-passing criterion with the `re.error` message embedded, instead of crashing evaluation.

## Motivation

Pipelines that gate on multiple terminal markers — e.g. accepting either `STATUS: APPROVED` or `STATUS: LGTM` from a reviewer node — currently can't express the OR. `success_criteria` evaluates with AND across the list, so listing two `output_contains` entries fails when only one marker appears. `output_regex` collapses the alternation into a single criterion.

Real use case: a Claude-led Codex review loop ([claude-codex-teamflow](https://github.com/osama-2000236/claude-codex-teamflow)) where reviewer Claude may approve with either `APPROVED` or `LGTM`. With this PR the gate becomes:

\`\`\`python
success_criteria=[
    {"kind": "output_regex", "value": r"^STATUS:\s+(APPROVED|LGTM)\b"},
],
\`\`\`

## Test plan

- [x] `OutputRegexCriterion` round-trips through Pydantic discriminated union (manual import + instantiation).
- [x] `evaluate_success` matches `STATUS: LGTM` and `STATUS: APPROVED`, rejects `STATUS: CHANGES_REQUESTED`.
- [x] Invalid regex returns `passed=False` with embedded `re.error` message (no traceback).
- [x] Sample pipeline using new criterion passes `agentflow validate`.
- [ ] Run existing test suite (no new tests added; happy to add some if you'd like a specific style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)