### PR TITLE
Add Cloud Hypervisor execution target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apk add --no-cache \
         curl \
         gcompat \
         git \
+        iproute2 \
         jq \
         libgcc \
         libstdc++ \
@@ -64,6 +65,11 @@ RUN uv pip install \
         --no-cache \
         . \
     && mkdir -p /workspace \
+        /agentflow-runtime \
+        /agentflow-app \
+        /inputs \
+        /outputs \
+        /reference \
     && command -v agentflow \
     && command -v codex \
     && command -v claude \
@@ -75,6 +81,7 @@ RUN uv pip install \
     && test -r /usr/lib/libnss_wrapper.so
 
 COPY --chmod=0755 docker/entrypoint.sh /usr/local/bin/agentflow-entrypoint
+COPY --chmod=0755 cloud_hypervisor/guest-init.sh /usr/local/bin/agentflow-cloud-hypervisor-init
 
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,51 @@ See [the pipeline reference](docs/pipelines.md#docker) for every field,
 custom-network examples, mount behavior, security notes, and compatibility
 with the older `kind: "container"` target.
 
+### Cloud Hypervisor
+
+`kind: "cloud_hypervisor"` boots each node in an ephemeral KVM VM. It uses a
+Cloud Hypervisor-compatible Linux kernel, a read-only root filesystem exported
+from the bundled all-agent Docker image, virtio-fs for workspace/runtime
+sharing, and vsock for the command and streaming output channel. Guest SSH and
+guest networking are not required for control:
+
+```bash
+docker build -t agentflow-agents:latest .
+mkdir -p .agentflow/cloud-hypervisor
+cloud_hypervisor/export-rootfs.sh \
+  agentflow-agents:latest .agentflow/cloud-hypervisor/rootfs
+
+curl -fL \
+  https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/vmlinux-x86_64 \
+  -o .agentflow/cloud-hypervisor/vmlinux-x86_64
+```
+
+The Linux host must provide `cloud-hypervisor`, a current Rust `virtiofsd`
+with UID/GID translation support, and read/write access to `/dev/kvm`.
+
+```python
+codex(
+    task_id="vm-review",
+    prompt="Review the repository in an isolated VM.",
+    target={
+        "kind": "cloud_hypervisor",
+        "kernel": ".agentflow/cloud-hypervisor/vmlinux-x86_64",
+        "rootfs": ".agentflow/cloud-hypervisor/rootfs",
+        "cpus": 4,
+        "memory_mib": 8192,
+        "workdir_read_only": True,
+        "network_policy": "none",
+    },
+)
+```
+
+The default network policy creates no network device. An explicit TAP policy
+can attach a host-managed interface for model/API access; routing, NAT,
+firewalling, and destination restrictions remain host responsibilities. Host
+credentials are not inherited unless `inherit_credentials: true` is set.
+See [the Cloud Hypervisor reference](docs/pipelines.md#cloud-hypervisor) for
+image preparation, TAP/static addressing, mount rules, and the guest contract.
+
 ### Remote machines
 
 Run agents on remote machines -- zero config needed:
@@ -310,6 +355,7 @@ Successful evolutions are stored under `.agentflow/tuned_agents/<name>/versions/
 | `ec2_remote.py` | Run codex on a remote EC2 instance |
 | `ecs_fargate.py` | Run codex on ECS Fargate |
 | `docker_target.py` | Exercise isolated, host-daemon, and Docker-in-Docker targets |
+| `cloud_hypervisor_target.py` | Boot an all-agent KVM guest through Cloud Hypervisor, virtio-fs, and vsock |
 
 ## Graph Optimization Rounds
 

--- a/agentflow/agents/codex.py
+++ b/agentflow/agents/codex.py
@@ -142,15 +142,15 @@ class CodexAdapter(AgentAdapter):
 
         runtime_files: dict[str, str] = {}
         runtime_symlinks: dict[str, str] = {}
-        is_docker_target = getattr(node.target, "kind", None) == "docker"
-        inherit_host_credentials = not is_docker_target or bool(
+        is_isolated_target = getattr(node.target, "kind", None) in {"docker", "cloud_hypervisor"}
+        inherit_host_credentials = not is_isolated_target or bool(
             getattr(node.target, "inherit_credentials", False)
         )
         needs_scoped_home = bool(
             provider
             or node.mcps
             or repo_instructions_ignored
-            or (is_docker_target and inherit_host_credentials)
+            or (is_isolated_target and inherit_host_credentials)
         )
         if needs_scoped_home:
             codex_home = str(Path(paths.target_runtime_dir) / "codex_home")

--- a/agentflow/agents/util.py
+++ b/agentflow/agents/util.py
@@ -46,8 +46,8 @@ class SyncAdapter:
     def prepare(self, node: NodeSpec, prompt: str, paths: ExecutionPaths) -> PreparedExecution:
         if node.target.kind not in {"ssh", "ec2", "ecs"}:
             raise ValueError(
-                "sync nodes require an `ssh`, `ec2`, or `ecs` target; Docker/container targets already "
-                "use the local pipeline workspace as a bind mount"
+                "sync nodes require an `ssh`, `ec2`, or `ecs` target; container, Docker, and Cloud "
+                "Hypervisor targets already share the local pipeline workspace"
             )
         mode = prompt.strip().lower()
         if mode not in ("repo", "full"):

--- a/agentflow/cloud_hypervisor_guest.py
+++ b/agentflow/cloud_hypervisor_guest.py
@@ -1,0 +1,570 @@
+"""Single-request AgentFlow guest agent for Cloud Hypervisor VMs.
+
+The host connects through Cloud Hypervisor's Unix-to-vsock proxy. The guest
+mounts the advertised virtio-fs shares, configures the optional TAP interface,
+executes one command, and streams newline-delimited JSON events back to the
+host. This module intentionally depends only on Python's standard library so it
+can run as PID 1 in the exported AgentFlow image root filesystem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import codecs
+import contextlib
+import ctypes
+import json
+import os
+import posixpath
+import re
+import selectors
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, BinaryIO
+
+_PROTOCOL_VERSION = 1
+_MAX_REQUEST_BYTES = 16 * 1024 * 1024
+_MAX_STREAM_CHUNK_BYTES = 8 * 1024
+_STREAM_DRAIN_SECONDS = 3.0
+_ALLOWED_TAG = re.compile(r"^agentflow-[A-Za-z0-9_.-]+$")
+_RESERVED_TARGETS = ("/dev", "/proc", "/run", "/sys")
+# CPython only exposes these names when it was built against libc headers that
+# define AF_VSOCK.  The bundled musl Python can still use Linux vsock sockets by
+# passing the stable UAPI numeric values directly.
+_LINUX_AF_VSOCK = 40
+_LINUX_VMADDR_CID_ANY = 0xFFFFFFFF
+_SU_EXEC_PATH = "/sbin/su-exec"
+_ENV_PATH = "/usr/bin/env"
+_SHELL_PATH = "/bin/sh"
+
+
+class GuestRequestError(ValueError):
+    """The host sent an invalid or unsupported guest request."""
+
+
+def _send_event(stream: BinaryIO, payload: dict[str, Any]) -> None:
+    encoded = (
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        + b"\n"
+    )
+    stream.write(encoded)
+    stream.flush()
+
+
+def _run_checked(command: list[str], *, description: str) -> None:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode == 0:
+        return
+    detail = (result.stderr or result.stdout).strip()
+    suffix = f": {detail}" if detail else ""
+    raise GuestRequestError(
+        f"{description} failed with status {result.returncode}{suffix}"
+    )
+
+
+def _paths_overlap(left: str, right: str) -> bool:
+    left = posixpath.normpath(left)
+    right = posixpath.normpath(right)
+    return (
+        left == right
+        or left.startswith(right.rstrip("/") + "/")
+        or right.startswith(left.rstrip("/") + "/")
+    )
+
+
+def _validate_mounts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise GuestRequestError("`mounts` must be a list")
+    mounts: list[dict[str, Any]] = []
+    targets: list[str] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise GuestRequestError("each mount must be an object")
+        tag = item.get("tag")
+        target = item.get("target")
+        read_only = item.get("read_only")
+        if not isinstance(tag, str) or not _ALLOWED_TAG.fullmatch(tag):
+            raise GuestRequestError(f"invalid virtio-fs tag: {tag!r}")
+        if (
+            not isinstance(target, str)
+            or not target.startswith("/")
+            or target.startswith("//")
+        ):
+            raise GuestRequestError(
+                f"mount target must be an absolute guest path: {target!r}"
+            )
+        target = posixpath.normpath(target)
+        if target == "/" or any(
+            _paths_overlap(target, reserved) for reserved in _RESERVED_TARGETS
+        ):
+            raise GuestRequestError(
+                f"mount target overlaps a reserved guest path: {target}"
+            )
+        if not isinstance(read_only, bool):
+            raise GuestRequestError(f"mount `read_only` must be boolean for {target}")
+        if any(_paths_overlap(target, existing) for existing in targets):
+            raise GuestRequestError(
+                f"mount target overlaps another guest share: {target}"
+            )
+        targets.append(target)
+        mounts.append({"tag": tag, "target": target, "read_only": read_only})
+    return mounts
+
+
+def _mount_shares(mounts: list[dict[str, Any]]) -> None:
+    for mount in mounts:
+        target = Path(mount["target"])
+        if not target.is_dir():
+            raise GuestRequestError(
+                f"virtio-fs mount point must already exist in the read-only guest rootfs: {target}"
+            )
+        options = "ro" if mount["read_only"] else "rw"
+        _run_checked(
+            ["mount", "-t", "virtiofs", "-o", options, mount["tag"], str(target)],
+            description=f"mounting virtio-fs tag {mount['tag']} at {target}",
+        )
+
+
+_RUNTIME_RESOLV_CONF = Path("/run/agentflow-resolv.conf")
+_RUNTIME_DHCP_CONFIG = Path("/run/agentflow-udhcpc.conf")
+
+
+def _bind_resolv_conf(path: Path) -> None:
+    _run_checked(
+        ["mount", "--bind", str(path), "/etc/resolv.conf"],
+        description="installing guest DNS config",
+    )
+
+
+def _write_resolv_conf(dns_servers: list[str], *, already_bound: bool) -> bool:
+    if not dns_servers:
+        return already_bound
+    path = _RUNTIME_RESOLV_CONF
+    path.write_text(
+        "".join(f"nameserver {server}\n" for server in dns_servers), encoding="utf-8"
+    )
+    if not already_bound:
+        _bind_resolv_conf(path)
+    return True
+
+
+def _configure_dhcp() -> bool:
+    # Alpine's default udhcpc script writes a sibling temporary file before
+    # replacing resolv.conf. The guest rootfs is intentionally read-only, so
+    # point that script at /run through its existing configuration hook.
+    _RUNTIME_DHCP_CONFIG.write_text(
+        f'RESOLV_CONF="{_RUNTIME_RESOLV_CONF}"\n', encoding="utf-8"
+    )
+    _run_checked(
+        [
+            "mount",
+            "--bind",
+            str(_RUNTIME_DHCP_CONFIG),
+            "/etc/udhcpc/udhcpc.conf",
+        ],
+        description="installing read-only-rootfs DHCP config",
+    )
+    _run_checked(
+        ["udhcpc", "-q", "-n", "-i", "eth0"],
+        description="guest DHCP configuration",
+    )
+    if _RUNTIME_RESOLV_CONF.is_file():
+        _bind_resolv_conf(_RUNTIME_RESOLV_CONF)
+        return True
+    return False
+
+
+def _configure_network(value: Any) -> None:
+    if not isinstance(value, dict):
+        raise GuestRequestError("`network` must be an object")
+    mode = value.get("mode")
+    if mode not in {"none", "tap"}:
+        raise GuestRequestError(f"unsupported network mode: {mode!r}")
+
+    with open(os.devnull, "wb") as devnull:
+        subprocess.run(
+            ["ip", "link", "set", "lo", "up"],
+            stdout=devnull,
+            stderr=devnull,
+            check=False,
+        )
+    if mode == "none":
+        return
+
+    _run_checked(
+        ["ip", "link", "set", "eth0", "up"], description="bringing guest eth0 up"
+    )
+    guest_address = value.get("guest_address")
+    gateway = value.get("gateway")
+    dhcp = value.get("dhcp")
+    dns = value.get("dns")
+    if (
+        not isinstance(dhcp, bool)
+        or not isinstance(dns, list)
+        or not all(isinstance(item, str) for item in dns)
+    ):
+        raise GuestRequestError("invalid guest network configuration")
+    resolv_conf_bound = False
+    if dhcp:
+        resolv_conf_bound = _configure_dhcp()
+    elif guest_address is not None:
+        if not isinstance(guest_address, str):
+            raise GuestRequestError("`network.guest_address` must be a string")
+        _run_checked(
+            ["ip", "address", "add", guest_address, "dev", "eth0"],
+            description="setting guest address",
+        )
+        if gateway is not None:
+            if not isinstance(gateway, str):
+                raise GuestRequestError("`network.gateway` must be a string")
+            _run_checked(
+                ["ip", "route", "replace", "default", "via", gateway],
+                description="setting guest gateway",
+            )
+    _write_resolv_conf(dns, already_bound=resolv_conf_bound)
+
+
+def _validate_request(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GuestRequestError("request must be an object")
+    if value.get("protocol") != _PROTOCOL_VERSION:
+        raise GuestRequestError(
+            f"unsupported protocol version: {value.get('protocol')!r}"
+        )
+    command = value.get("command")
+    if (
+        not isinstance(command, list)
+        or not command
+        or not all(
+            isinstance(item, str) and item and "\x00" not in item for item in command
+        )
+    ):
+        raise GuestRequestError(
+            "`command` must be a non-empty string list without NUL bytes"
+        )
+    env = value.get("env")
+    if not isinstance(env, dict) or not all(
+        isinstance(key, str)
+        and key
+        and "=" not in key
+        and "\x00" not in key
+        and isinstance(item, str)
+        and "\x00" not in item
+        for key, item in env.items()
+    ):
+        raise GuestRequestError("`env` must be a NUL-free environment mapping")
+    cwd = value.get("cwd")
+    if (
+        not isinstance(cwd, str)
+        or not cwd.startswith("/")
+        or cwd.startswith("//")
+        or "\x00" in cwd
+    ):
+        raise GuestRequestError("`cwd` must be an absolute guest path")
+    stdin = value.get("stdin")
+    if stdin is not None and not isinstance(stdin, str):
+        raise GuestRequestError("`stdin` must be a string or null")
+    uid = value.get("uid")
+    gid = value.get("gid")
+    if (
+        not isinstance(uid, int)
+        or isinstance(uid, bool)
+        or not 0 <= uid <= 4_294_967_294
+        or not isinstance(gid, int)
+        or isinstance(gid, bool)
+        or not 0 <= gid <= 4_294_967_294
+    ):
+        raise GuestRequestError("`uid` and `gid` must be Linux 32-bit identifiers")
+    return {
+        "command": command,
+        "env": env,
+        "cwd": posixpath.normpath(cwd),
+        "stdin": stdin,
+        "uid": uid,
+        "gid": gid,
+        "mounts": _validate_mounts(value.get("mounts")),
+        "network": value.get("network"),
+    }
+
+
+def _stdin_writer(pipe: BinaryIO, content: str | None) -> None:
+    try:
+        if content is not None:
+            pipe.write(content.encode("utf-8"))
+            pipe.flush()
+    except BrokenPipeError:
+        pass
+    finally:
+        pipe.close()
+
+
+def _send_stream_text(
+    protocol_stream: BinaryIO,
+    stream_name: str,
+    content: str,
+    *,
+    line_end: bool,
+) -> None:
+    chunks = [
+        content[offset : offset + _MAX_STREAM_CHUNK_BYTES]
+        for offset in range(0, len(content), _MAX_STREAM_CHUNK_BYTES)
+    ] or [""]
+    for index, chunk in enumerate(chunks):
+        _send_event(
+            protocol_stream,
+            {
+                "event": "stream",
+                "stream": stream_name,
+                "text": chunk,
+                "line_end": line_end and index == len(chunks) - 1,
+            },
+        )
+
+
+def _stream_process(process: subprocess.Popen[bytes], protocol_stream: BinaryIO) -> int:
+    assert process.stdout is not None
+    assert process.stderr is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    pending = {"stdout": b"", "stderr": b""}
+    decoders = {
+        "stdout": codecs.getincrementaldecoder("utf-8")("replace"),
+        "stderr": codecs.getincrementaldecoder("utf-8")("replace"),
+    }
+    line_fragment_sent = {"stdout": False, "stderr": False}
+
+    def send_decoded(stream_name: str, content: bytes, *, final: bool) -> None:
+        decoder = decoders[stream_name]
+        text = decoder.decode(content, final=final)
+        if text:
+            _send_stream_text(protocol_stream, stream_name, text, line_end=final)
+            line_fragment_sent[stream_name] = not final
+        elif final:
+            _send_stream_text(protocol_stream, stream_name, "", line_end=True)
+            line_fragment_sent[stream_name] = False
+        if final:
+            decoder.reset()
+
+    def finish_stream(file_object: BinaryIO, stream_name: str) -> None:
+        with contextlib.suppress(KeyError):
+            selector.unregister(file_object)
+        remainder = pending[stream_name]
+        buffered_input = bool(decoders[stream_name].getstate()[0])
+        if remainder or buffered_input or line_fragment_sent[stream_name]:
+            send_decoded(stream_name, remainder, final=True)
+        pending[stream_name] = b""
+
+    exit_seen_at: float | None = None
+    while selector.get_map():
+        events = selector.select(timeout=0.2)
+        for key, _ in events:
+            chunk = os.read(key.fileobj.fileno(), 64 * 1024)
+            stream_name = key.data
+            if not chunk:
+                finish_stream(key.fileobj, stream_name)
+                continue
+            buffered = pending[stream_name] + chunk
+            lines = buffered.split(b"\n")
+            pending[stream_name] = lines.pop()
+            for line in lines:
+                send_decoded(stream_name, line, final=True)
+            while len(pending[stream_name]) > _MAX_STREAM_CHUNK_BYTES:
+                ready_chunk = pending[stream_name][:_MAX_STREAM_CHUNK_BYTES]
+                pending[stream_name] = pending[stream_name][_MAX_STREAM_CHUNK_BYTES:]
+                send_decoded(stream_name, ready_chunk, final=False)
+
+        if process.poll() is not None:
+            if exit_seen_at is None:
+                exit_seen_at = time.monotonic()
+            if time.monotonic() - exit_seen_at >= _STREAM_DRAIN_SECONDS:
+                for key in list(selector.get_map().values()):
+                    finish_stream(key.fileobj, key.data)
+                break
+    return process.wait()
+
+
+def _command_for_identity(
+    command: list[str], env: dict[str, str], uid: int, gid: int
+) -> tuple[list[str], dict[str, str]]:
+    if (uid, gid) == (0, 0):
+        return list(command), env
+
+    # Do not let request-controlled PATH or dynamic-loader variables affect the
+    # root process responsible for dropping privileges. The minimal launcher
+    # has an empty environment and passes the requested environment as argv to
+    # `env` only after su-exec has changed UID/GID. The small shell wrapper
+    # preserves command names that themselves contain `=`.
+    assignments = [f"{key}={value}" for key, value in env.items()]
+    return (
+        [
+            _SU_EXEC_PATH,
+            f"{uid}:{gid}",
+            _ENV_PATH,
+            "-i",
+            "--",
+            *assignments,
+            _SHELL_PATH,
+            "-c",
+            'exec -- "$@"',
+            "agentflow-command",
+            *command,
+        ],
+        {},
+    )
+
+
+def _execute_request(request: dict[str, Any], protocol_stream: BinaryIO) -> int:
+    _mount_shares(request["mounts"])
+    _configure_network(request["network"])
+    cwd = Path(request["cwd"])
+    if not cwd.is_dir():
+        raise GuestRequestError(f"guest working directory does not exist: {cwd}")
+
+    env = os.environ.copy()
+    env.update(request["env"])
+    home = env.get("HOME")
+    if not home or not Path(home).is_dir():
+        raise GuestRequestError(
+            f"guest HOME must name a pre-created runtime directory: {home!r}"
+        )
+
+    uid = request["uid"]
+    gid = request["gid"]
+    command, launch_env = _command_for_identity(list(request["command"]), env, uid, gid)
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=request["cwd"],
+        env=launch_env,
+    )
+    assert process.stdin is not None
+    stdin_thread = threading.Thread(
+        target=_stdin_writer, args=(process.stdin, request["stdin"]), daemon=True
+    )
+    stdin_thread.start()
+    _send_event(protocol_stream, {"event": "started", "pid": process.pid})
+    exit_code = _stream_process(process, protocol_stream)
+    stdin_thread.join(timeout=1.0)
+    return exit_code
+
+
+class _SockAddrVm(ctypes.Structure):
+    _fields_ = [
+        ("family", ctypes.c_ushort),
+        ("reserved", ctypes.c_ushort),
+        ("port", ctypes.c_uint32),
+        ("cid", ctypes.c_uint32),
+        ("zero", ctypes.c_ubyte * 4),
+    ]
+
+
+def _accept_vsock_without_python_address_support(port: int) -> int:
+    """Accept one Linux vsock connection when CPython lacks sockaddr_vm support."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.socket.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int]
+    libc.socket.restype = ctypes.c_int
+    libc.bind.argtypes = [
+        ctypes.c_int,
+        ctypes.POINTER(_SockAddrVm),
+        ctypes.c_uint32,
+    ]
+    libc.bind.restype = ctypes.c_int
+    libc.listen.argtypes = [ctypes.c_int, ctypes.c_int]
+    libc.listen.restype = ctypes.c_int
+    libc.accept.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p]
+    libc.accept.restype = ctypes.c_int
+
+    def checked(result: int, operation: str) -> int:
+        if result >= 0:
+            return result
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, f"vsock {operation}: {os.strerror(error_number)}")
+
+    listener_fd = checked(libc.socket(_LINUX_AF_VSOCK, socket.SOCK_STREAM, 0), "socket")
+    try:
+        address = _SockAddrVm(
+            family=_LINUX_AF_VSOCK,
+            reserved=0,
+            port=port,
+            cid=_LINUX_VMADDR_CID_ANY,
+        )
+        checked(
+            libc.bind(listener_fd, ctypes.byref(address), ctypes.sizeof(address)),
+            "bind",
+        )
+        checked(libc.listen(listener_fd, 1), "listen")
+        return checked(libc.accept(listener_fd, None, None), "accept")
+    finally:
+        os.close(listener_fd)
+
+
+def _handle_connection(protocol_stream: BinaryIO) -> int:
+    _send_event(protocol_stream, {"event": "hello", "protocol": _PROTOCOL_VERSION})
+    line = protocol_stream.readline(_MAX_REQUEST_BYTES + 1)
+    if not line:
+        raise GuestRequestError("host disconnected before sending a request")
+    if len(line) > _MAX_REQUEST_BYTES or not line.endswith(b"\n"):
+        raise GuestRequestError(
+            "guest request exceeds the 16 MiB single-line protocol limit"
+        )
+    try:
+        request = _validate_request(json.loads(line))
+        exit_code = _execute_request(request, protocol_stream)
+    except (
+        GuestRequestError,
+        OSError,
+        subprocess.SubprocessError,
+        ValueError,
+    ) as exc:
+        _send_event(protocol_stream, {"event": "error", "message": str(exc)})
+        return 1
+    _send_event(protocol_stream, {"event": "result", "exit_code": exit_code})
+    return 0
+
+
+def _serve_one(port: int) -> int:
+    if hasattr(socket, "AF_VSOCK") and hasattr(socket, "VMADDR_CID_ANY"):
+        listener = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+        listener.bind((socket.VMADDR_CID_ANY, port))
+        listener.listen(1)
+        connection, _ = listener.accept()
+        listener.close()
+        with connection, connection.makefile("rwb", buffering=0) as protocol_stream:
+            return _handle_connection(protocol_stream)
+
+    connection_fd = _accept_vsock_without_python_address_support(port)
+    with os.fdopen(connection_fd, "r+b", buffering=0) as protocol_stream:
+        return _handle_connection(protocol_stream)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="AgentFlow Cloud Hypervisor guest agent"
+    )
+    parser.add_argument("--port", type=int, default=4050)
+    args = parser.parse_args(argv)
+    if not 1 <= args.port <= 65535:
+        parser.error("--port must be between 1 and 65535")
+    try:
+        return _serve_one(args.port)
+    except (
+        GuestRequestError,
+        OSError,
+        RuntimeError,
+        subprocess.SubprocessError,
+        ValueError,
+    ) as exc:
+        print(f"agentflow-cloud-hypervisor-guest: {exc}", file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentflow/inspection.py
+++ b/agentflow/inspection.py
@@ -175,6 +175,12 @@ def _payload_summary(node_plan: dict[str, Any]) -> str | None:
         engine = payload.get("engine")
         if image and engine:
             return f"{engine} image={image}"
+    if launch["kind"] == "cloud_hypervisor":
+        binary = payload.get("binary")
+        kernel = payload.get("kernel")
+        rootfs = payload.get("rootfs")
+        if binary and kernel and rootfs:
+            return f"{binary} kernel={kernel}, rootfs={rootfs}"
     if launch["kind"] in ("ec2", "ecs"):
         function_name = payload.get("function_name")
         invocation_type = payload.get("invocation_type")
@@ -404,8 +410,10 @@ def _auth_summary(
             helper_bootstrap_source,
         )
 
-    if getattr(target, "kind", None) == "docker":
-        docker_env = prepared_env or {}
+    isolated_kind = getattr(target, "kind", None)
+    if isolated_kind in {"docker", "cloud_hypervisor"}:
+        isolated_env = prepared_env or {}
+        target_name = "Docker" if isolated_kind == "docker" else "Cloud Hypervisor"
         prepared_key = next(
             (
                 key
@@ -414,15 +422,15 @@ def _auth_summary(
                     "ANTHROPIC_API_KEY" if node.agent == AgentKind.CLAUDE else "",
                     "KIMI_API_KEY" if node.agent == AgentKind.KIMI else "",
                 )
-                if key and _has_nonempty_env_value(docker_env, key)
+                if key and _has_nonempty_env_value(isolated_env, key)
             ),
             None,
         )
         if prepared_key is not None:
             if prepared_key == api_key_env:
-                return f"`{api_key_env}` via adapter-prepared Docker environment"
+                return f"`{api_key_env}` via adapter-prepared {target_name} environment"
             return (
-                f"`{prepared_key}` prepared for Docker from `{api_key_env}` by the "
+                f"`{prepared_key}` prepared for {target_name} from `{api_key_env}` by the "
                 f"{normalize_agent_name(node.agent)} adapter"
             )
 
@@ -436,11 +444,11 @@ def _auth_summary(
 
         if node.agent == AgentKind.CODEX:
             return (
-                "Docker target expects `OPENAI_API_KEY` via `node.env`/`provider.env`, or a Codex CLI login "
+                f"{target_name} target expects `OPENAI_API_KEY` via `node.env`/`provider.env`, or a Codex CLI login "
                 "via `target.inherit_credentials`; current environment and host CLI homes are not inherited"
             )
         return (
-            f"Docker target expects `{api_key_env}` via `node.env` or `provider.env`; current environment "
+            f"{target_name} target expects `{api_key_env}` via `node.env` or `provider.env`; current environment "
             "and host CLI homes are not inherited"
         )
 
@@ -655,6 +663,24 @@ def _target_warnings(
             warnings.append(
                 "Docker host networking shares the host network namespace; the container can reach host-local "
                 "listeners and is not network-isolated."
+            )
+
+    if target.get("kind") == "cloud_hypervisor":
+        if target.get("seccomp") == "false":
+            warnings.append(
+                "Cloud Hypervisor seccomp filtering is disabled; the host-side VMM process has a broader "
+                "system-call attack surface."
+            )
+        if target.get("inherit_credentials"):
+            warnings.append(
+                "Cloud Hypervisor credential inheritance copies adapter-selected host credential/config files "
+                "into the VM's private runtime share."
+            )
+        network_policy = target.get("network_policy")
+        if isinstance(network_policy, dict) and network_policy.get("mode") == "tap":
+            warnings.append(
+                "Cloud Hypervisor TAP networking uses host-managed routing and firewall policy; the target "
+                "configuration is not a destination allowlist."
             )
 
     effective_home = target_bash_home(target, env=launch_env, cwd=cwd)
@@ -1012,10 +1038,9 @@ def _launch_env_inheritance_details(
     *,
     cwd: str | None = None,
 ) -> list[dict[str, Any]]:
-    # Docker receives only variables explicitly emitted as `docker run --env`;
-    # the Docker CLI process inheriting a host variable does not put it inside
-    # the launched container.
-    if getattr(node.target, "kind", None) == "docker":
+    # Isolated targets receive only variables in their prepared guest/container
+    # environment. The host launcher inheriting a variable does not forward it.
+    if getattr(node.target, "kind", None) in {"docker", "cloud_hypervisor"}:
         return []
 
     key = _ambient_base_url_env_key(node)
@@ -1133,7 +1158,7 @@ def build_launch_inspection(
                 "trace_kind": prepared.trace_kind,
                 "env": (
                     {key: _REDACTED for key in sorted(prepared.env)}
-                    if execution_node.target.kind == "docker"
+                    if execution_node.target.kind in {"docker", "cloud_hypervisor"}
                     else _sanitize_env(prepared.env)
                 ),
                 "env_keys": sorted(prepared.env),

--- a/agentflow/loader.py
+++ b/agentflow/loader.py
@@ -93,7 +93,7 @@ def _resolve_file_relative_paths(parsed: dict[str, Any], base_dir: Path) -> dict
                 updated_target["cwd"] = str((working_dir / expanded_cwd).resolve())
             return updated_target
 
-        if kind != "docker":
+        if kind not in {"docker", "cloud_hypervisor"}:
             return target
 
         updated_target = dict(target)
@@ -114,12 +114,22 @@ def _resolve_file_relative_paths(parsed: dict[str, Any], base_dir: Path) -> dict
                 resolved_mounts.append(mount)
             updated_target["mounts"] = resolved_mounts
 
-        daemon_socket = updated_target.get("docker_daemon_socket")
-        if isinstance(daemon_socket, str) and daemon_socket.strip():
-            expanded_socket = Path(daemon_socket.strip()).expanduser()
-            updated_target["docker_daemon_socket"] = (
-                str(expanded_socket.resolve()) if expanded_socket.is_absolute() else str(expanded_socket)
-            )
+        if kind == "docker":
+            daemon_socket = updated_target.get("docker_daemon_socket")
+            if isinstance(daemon_socket, str) and daemon_socket.strip():
+                expanded_socket = Path(daemon_socket.strip()).expanduser()
+                updated_target["docker_daemon_socket"] = (
+                    str(expanded_socket.resolve()) if expanded_socket.is_absolute() else str(expanded_socket)
+                )
+        else:
+            for field_name in ("kernel", "rootfs"):
+                raw_path = updated_target.get(field_name)
+                if not isinstance(raw_path, str) or not raw_path.strip():
+                    continue
+                expanded_path = Path(raw_path.strip()).expanduser()
+                if not expanded_path.is_absolute():
+                    expanded_path = working_dir / expanded_path
+                updated_target[field_name] = str(expanded_path.resolve())
         return updated_target
 
     local_target_defaults = resolved.get("local_target_defaults")

--- a/agentflow/prepared.py
+++ b/agentflow/prepared.py
@@ -52,7 +52,7 @@ def build_execution_paths(
         host_runtime_dir = ensure_dir(host_runtime_dir)
 
     app_root = Path(__file__).resolve().parents[1]
-    if node_target.kind in ("container", "docker"):
+    if node_target.kind in ("container", "docker", "cloud_hypervisor"):
         host_workdir = pipeline_workdir
         target_workdir = node_target.workdir_mount
         target_runtime_dir = node_target.runtime_mount

--- a/agentflow/runners/cloud_hypervisor.py
+++ b/agentflow/runners/cloud_hypervisor.py
@@ -1,0 +1,1167 @@
+"""Cloud Hypervisor execution through virtio-fs and a small vsock guest agent."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, BinaryIO
+
+from agentflow.prepared import ExecutionPaths, PreparedExecution
+from agentflow.runners.base import (
+    CancelCallback,
+    LaunchPlan,
+    RawExecutionResult,
+    Runner,
+    StreamCallback,
+)
+from agentflow.specs import CloudHypervisorTarget, NodeSpec
+
+_PROTOCOL_VERSION = 1
+_MAX_REQUEST_BYTES = 16 * 1024 * 1024
+_MAX_GUEST_EVENT_BYTES = 256 * 1024
+_MAX_LOGICAL_STREAM_LINE_CHARS = 16 * 1024 * 1024
+_MAX_STREAM_FRAGMENTS_PER_LINE = 4096
+_ROOTFS_TAG = "/dev/root"
+_MAX_UNIX_SOCKET_PATH_BYTES = 100
+_NSS_DIRECTORY = ".agentflow-nss"
+
+
+@dataclass(frozen=True, slots=True)
+class _VirtioFsShare:
+    tag: str
+    source: Path
+    target: str | None
+    read_only: bool
+    socket: Path
+
+
+class CloudHypervisorRunner(Runner):
+    """Boot one ephemeral VM per node and execute through a vsock protocol."""
+
+    def _target(self, node: NodeSpec) -> CloudHypervisorTarget:
+        target = node.target
+        if not isinstance(target, CloudHypervisorTarget):
+            raise TypeError("CloudHypervisorRunner requires a CloudHypervisorTarget")
+        return target
+
+    def _resolve_host_path(self, value: str | Path, paths: ExecutionPaths) -> Path:
+        candidate = Path(value).expanduser()
+        if not candidate.is_absolute():
+            candidate = paths.host_workdir / candidate
+        return candidate.resolve()
+
+    def _host_paths_overlap(self, left: Path, right: Path) -> bool:
+        left = left.resolve()
+        right = right.resolve()
+        try:
+            left.relative_to(right)
+            return True
+        except ValueError:
+            pass
+        try:
+            right.relative_to(left)
+            return True
+        except ValueError:
+            return False
+
+    def _state_dir(self, paths: ExecutionPaths) -> Path:
+        identity = str(paths.host_runtime_dir.resolve()).encode("utf-8")
+        suffix = hashlib.sha256(identity).hexdigest()[:20]
+        return Path(tempfile.gettempdir()) / f"agentflow-ch-{suffix}"
+
+    def _socket_path(self, state_dir: Path, name: str) -> Path:
+        path = state_dir / name
+        if "," in str(path):
+            raise ValueError(
+                f"Cloud Hypervisor Unix socket paths must not contain commas: {path}"
+            )
+        if len(os.fsencode(path)) > _MAX_UNIX_SOCKET_PATH_BYTES:
+            raise ValueError(
+                "Cloud Hypervisor runtime path is too long for Unix sockets; configure a shorter "
+                f"AgentFlow base directory (socket would be `{path}`)"
+            )
+        return path
+
+    def _effective_guest_ids(self, target: CloudHypervisorTarget) -> tuple[int, int]:
+        if target.user == "host":
+            if not hasattr(os, "getuid") or not hasattr(os, "getgid"):
+                raise ValueError("`target.user: host` requires a POSIX host")
+            return os.getuid(), os.getgid()
+        if target.user in {None, "root", "0", "0:0"}:
+            return 0, 0
+        assert target.user is not None
+        uid_text, separator, gid_text = target.user.partition(":")
+        uid = int(uid_text)
+        return uid, int(gid_text) if separator else uid
+
+    def _vsock_cid(self, target: CloudHypervisorTarget, paths: ExecutionPaths) -> int:
+        if target.vsock_cid is not None:
+            return target.vsock_cid
+        identity = str(paths.host_runtime_dir.resolve()).encode("utf-8")
+        value = int.from_bytes(hashlib.sha256(identity).digest()[:4], "big")
+        return 3 + (value % (4_294_967_295 - 3))
+
+    def _shares(
+        self,
+        target: CloudHypervisorTarget,
+        paths: ExecutionPaths,
+    ) -> list[_VirtioFsShare]:
+        state_dir = self._state_dir(paths)
+        rootfs_source = self._resolve_host_path(target.rootfs, paths)
+        workspace_source = paths.host_workdir.resolve()
+        runtime_source = paths.host_runtime_dir.resolve()
+        if not target.workdir_read_only and self._host_paths_overlap(
+            workspace_source, rootfs_source
+        ):
+            raise ValueError(
+                "the writable managed workspace overlaps the immutable guest rootfs; "
+                "move the rootfs outside the workspace or set `target.workdir_read_only: true`"
+            )
+        if self._host_paths_overlap(runtime_source, rootfs_source):
+            raise ValueError(
+                "the writable managed runtime overlaps the immutable guest rootfs; "
+                "move the rootfs or AgentFlow runs directory"
+            )
+        if (
+            target.app_mount is not None
+            and not target.workdir_read_only
+            and self._host_paths_overlap(workspace_source, paths.app_root)
+        ):
+            raise ValueError(
+                "the writable managed workspace overlaps the read-only managed AgentFlow app; "
+                "omit `target.app_mount` or use a read-only/separate workspace"
+            )
+        raw_shares: list[tuple[str, Path, str | None, bool]] = [
+            (
+                _ROOTFS_TAG,
+                rootfs_source,
+                None,
+                True,
+            ),
+            (
+                "agentflow-workspace",
+                workspace_source,
+                target.workdir_mount,
+                target.workdir_read_only,
+            ),
+            (
+                "agentflow-runtime",
+                runtime_source,
+                target.runtime_mount,
+                False,
+            ),
+        ]
+        if target.app_mount is not None:
+            raw_shares.append(
+                (
+                    "agentflow-app",
+                    paths.app_root.resolve(),
+                    target.app_mount,
+                    True,
+                )
+            )
+        explicit_sources: list[tuple[Path, bool]] = []
+        for index, mount in enumerate(target.mounts):
+            source = self._resolve_host_path(mount.source, paths)
+            if not mount.read_only and self._host_paths_overlap(source, rootfs_source):
+                raise ValueError(
+                    "a read-write Cloud Hypervisor mount source overlaps the immutable guest rootfs: "
+                    f"{source}"
+                )
+            if (
+                not mount.read_only
+                and target.workdir_read_only
+                and self._host_paths_overlap(source, paths.host_workdir)
+            ):
+                raise ValueError(
+                    "a read-write Cloud Hypervisor mount source overlaps the read-only managed workspace: "
+                    f"{source}"
+                )
+            if (
+                not mount.read_only
+                and target.app_mount is not None
+                and self._host_paths_overlap(source, paths.app_root)
+            ):
+                raise ValueError(
+                    "a read-write Cloud Hypervisor mount source overlaps the read-only managed AgentFlow app: "
+                    f"{source}"
+                )
+            if (
+                mount.read_only
+                and not target.workdir_read_only
+                and self._host_paths_overlap(source, paths.host_workdir)
+            ):
+                raise ValueError(
+                    "a read-only Cloud Hypervisor mount source overlaps the writable managed workspace: "
+                    f"{source}"
+                )
+            if mount.read_only and self._host_paths_overlap(
+                source, paths.host_runtime_dir
+            ):
+                raise ValueError(
+                    "a read-only Cloud Hypervisor mount source overlaps the writable managed runtime: "
+                    f"{source}"
+                )
+            for previous_source, previous_read_only in explicit_sources:
+                if mount.read_only != previous_read_only and self._host_paths_overlap(
+                    source, previous_source
+                ):
+                    raise ValueError(
+                        "read-only and read-write Cloud Hypervisor mount sources must not overlap: "
+                        f"{previous_source} <> {source}"
+                    )
+            explicit_sources.append((source, mount.read_only))
+            raw_shares.append(
+                (
+                    f"agentflow-mount-{index:03d}",
+                    source,
+                    mount.target,
+                    mount.read_only,
+                )
+            )
+        return [
+            _VirtioFsShare(
+                tag=tag,
+                source=source,
+                target=guest_target,
+                read_only=read_only,
+                socket=self._socket_path(state_dir, f"fs-{index:03d}.sock"),
+            )
+            for index, (tag, source, guest_target, read_only) in enumerate(raw_shares)
+        ]
+
+    def _kernel_cmdline(self, target: CloudHypervisorTarget) -> str:
+        arguments = [
+            "console=ttyS0",
+            f"root={_ROOTFS_TAG}",
+            "rootfstype=virtiofs",
+            "ro",
+            f"init={target.init_path}",
+            f"agentflow.guest_port={target.guest_agent_port}",
+            "panic=1",
+            "reboot=k",
+            *target.kernel_args,
+        ]
+        return " ".join(arguments)
+
+    def _network_argument(self, target: CloudHypervisorTarget) -> str | None:
+        policy = target.network_policy
+        if policy.mode == "none":
+            return None
+        parts = [f"tap={policy.tap or ''}"]
+        if policy.mac is not None:
+            parts.append(f"mac={policy.mac}")
+        if policy.host_ip is not None:
+            parts.append(f"ip={policy.host_ip}")
+        if policy.host_mask is not None:
+            parts.append(f"mask={policy.host_mask}")
+        parts.append(f"num_queues={policy.num_queues}")
+        return ",".join(parts)
+
+    def _vmm_command(
+        self,
+        target: CloudHypervisorTarget,
+        paths: ExecutionPaths,
+        shares: list[_VirtioFsShare],
+    ) -> list[str]:
+        state_dir = self._state_dir(paths)
+        command = [
+            target.binary,
+            "--api-socket",
+            f"path={self._socket_path(state_dir, 'api.sock')}",
+            "--kernel",
+            str(self._resolve_host_path(target.kernel, paths)),
+            "--cmdline",
+            self._kernel_cmdline(target),
+            "--cpus",
+            f"boot={target.cpus}",
+            "--memory",
+            f"size={target.memory_mib}M,shared=on",
+            "--console",
+            "off",
+            "--serial",
+            f"file={state_dir / 'console.log'}",
+            "--seccomp",
+            target.seccomp,
+            "--vsock",
+            f"cid={self._vsock_cid(target, paths)},socket={self._socket_path(state_dir, 'vsock.sock')}",
+        ]
+        for share in shares:
+            command.extend(
+                [
+                    "--fs",
+                    f"tag={share.tag},socket={share.socket},num_queues=1,queue_size=512",
+                ]
+            )
+        network_argument = self._network_argument(target)
+        if network_argument is not None:
+            command.extend(["--net", network_argument])
+        return command
+
+    def _virtiofsd_command(
+        self,
+        target: CloudHypervisorTarget,
+        share: _VirtioFsShare,
+        guest_uid: int,
+        guest_gid: int,
+    ) -> list[str]:
+        host_uid = os.getuid() if hasattr(os, "getuid") else guest_uid
+        host_gid = os.getgid() if hasattr(os, "getgid") else guest_gid
+        command = [
+            target.virtiofsd,
+            f"--socket-path={share.socket}",
+            f"--shared-dir={share.source}",
+            "--cache=never",
+            "--log-level=warn",
+            f"--translate-uid=map:{guest_uid}:{host_uid}:1",
+            f"--translate-gid=map:{guest_gid}:{host_gid}:1",
+        ]
+        if share.read_only:
+            command.append("--readonly")
+        return command
+
+    def _prepare_private_runtime_target(
+        self, base_dir: Path, relative_path: str
+    ) -> Path:
+        relative = Path(relative_path)
+        if (
+            not relative.parts
+            or relative.is_absolute()
+            or ".." in relative.parts
+            or "\x00" in relative_path
+        ):
+            raise ValueError(
+                f"runtime file path must stay below the runtime directory: {relative_path}"
+            )
+        root = base_dir.resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        root.chmod(0o700)
+        parent = root
+        for part in relative.parts[:-1]:
+            parent = parent / part
+            if parent.is_symlink():
+                raise ValueError(f"runtime file parent must not be a symlink: {parent}")
+            parent.mkdir(exist_ok=True)
+            parent.chmod(0o700)
+        return parent / relative.parts[-1]
+
+    def materialize_runtime_files(
+        self, base_dir: Path, runtime_files: dict[str, str]
+    ) -> None:
+        for relative_path, content in runtime_files.items():
+            target = self._prepare_private_runtime_target(base_dir, relative_path)
+            if target.is_symlink() or (target.exists() and not target.is_dir()):
+                target.unlink()
+            if target.exists():
+                raise ValueError(
+                    f"runtime file target must not be a directory: {target}"
+                )
+            target.write_text(content, encoding="utf-8")
+            target.chmod(0o600)
+
+    def _materialize_inherited_credentials(
+        self,
+        target: CloudHypervisorTarget,
+        prepared: PreparedExecution,
+        paths: ExecutionPaths,
+    ) -> None:
+        if prepared.runtime_symlinks and not target.inherit_credentials:
+            raise ValueError(
+                "Cloud Hypervisor targets do not expose adapter-requested host credentials by default; "
+                "set `target.inherit_credentials: true` to copy selected files into the private VM runtime"
+            )
+        for relative_path, source in prepared.runtime_symlinks.items():
+            source_path = self._resolve_host_path(source, paths)
+            if not source_path.is_file():
+                raise ValueError(
+                    f"inherited Cloud Hypervisor credential must be a regular file: {source_path}"
+                )
+            destination = self._prepare_private_runtime_target(
+                paths.host_runtime_dir, relative_path
+            )
+            if destination.is_symlink() or (
+                destination.exists() and not destination.is_dir()
+            ):
+                destination.unlink()
+            if destination.exists():
+                raise ValueError(
+                    f"credential runtime target must not be a directory: {destination}"
+                )
+            destination.write_bytes(source_path.read_bytes())
+            destination.chmod(0o600)
+
+    def _validate_credentials_policy(
+        self,
+        target: CloudHypervisorTarget,
+        prepared: PreparedExecution,
+    ) -> None:
+        if prepared.runtime_symlinks and not target.inherit_credentials:
+            raise ValueError(
+                "Cloud Hypervisor targets do not expose adapter-requested host credentials by default; "
+                "set `target.inherit_credentials: true` to copy selected files into the private VM runtime"
+            )
+
+    def _nss_runtime_files(
+        self,
+        target: CloudHypervisorTarget,
+        paths: ExecutionPaths,
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        guest_uid, guest_gid = self._effective_guest_ids(target)
+        runtime_files: dict[str, str] = {}
+        env: dict[str, str] = {}
+        if guest_uid == 0 or target.nss_wrapper_path is None:
+            return runtime_files, env
+
+        passwd_relative = f"{_NSS_DIRECTORY}/passwd"
+        group_relative = f"{_NSS_DIRECTORY}/group"
+        runtime_files[passwd_relative] = (
+            "root:x:0:0:root:/root:/bin/sh\n"
+            f"agentflow:x:{guest_uid}:{guest_gid}:AgentFlow VM:{target.runtime_mount}/home:/bin/sh\n"
+        )
+        runtime_files[group_relative] = f"root:x:0:\nagentflow:x:{guest_gid}:\n"
+        env.update(
+            {
+                "NSS_WRAPPER_PASSWD": str(
+                    PurePosixPath(target.runtime_mount) / passwd_relative
+                ),
+                "NSS_WRAPPER_GROUP": str(
+                    PurePosixPath(target.runtime_mount) / group_relative
+                ),
+                "USER": "agentflow",
+                "LOGNAME": "agentflow",
+            }
+        )
+        current_preload = env.get("LD_PRELOAD", "")
+        env["LD_PRELOAD"] = (
+            f"{target.nss_wrapper_path}:{current_preload}"
+            if current_preload
+            else target.nss_wrapper_path
+        )
+        return runtime_files, env
+
+    def _guest_environment(
+        self,
+        target: CloudHypervisorTarget,
+        prepared: PreparedExecution,
+        nss_env: dict[str, str],
+    ) -> dict[str, str]:
+        env = dict(prepared.env)
+        if target.app_mount is not None:
+            inherited = env.get("PYTHONPATH", "").strip()
+            env["PYTHONPATH"] = (
+                f"{target.app_mount}:{inherited}" if inherited else target.app_mount
+            )
+        env.setdefault("HOME", f"{target.runtime_mount.rstrip('/')}/home")
+        guest_uid, _ = self._effective_guest_ids(target)
+        if guest_uid != 0 and nss_env:
+            original_preload = env.get("LD_PRELOAD", "")
+            env.update(nss_env)
+            if original_preload:
+                env["LD_PRELOAD"] = f"{nss_env['LD_PRELOAD']}:{original_preload}"
+        return env
+
+    def _guest_request(
+        self,
+        target: CloudHypervisorTarget,
+        prepared: PreparedExecution,
+        shares: list[_VirtioFsShare],
+        nss_env: dict[str, str],
+    ) -> dict[str, Any]:
+        guest_uid, guest_gid = self._effective_guest_ids(target)
+        policy = target.network_policy
+        return {
+            "protocol": _PROTOCOL_VERSION,
+            "command": list(prepared.command),
+            "env": self._guest_environment(target, prepared, nss_env),
+            "cwd": prepared.cwd,
+            "stdin": prepared.stdin,
+            "uid": guest_uid,
+            "gid": guest_gid,
+            "mounts": [
+                {
+                    "tag": share.tag,
+                    "target": share.target,
+                    "read_only": share.read_only,
+                }
+                for share in shares
+                if share.target is not None
+            ],
+            "network": {
+                "mode": policy.mode,
+                "dhcp": policy.dhcp,
+                "guest_address": policy.guest_address,
+                "gateway": policy.gateway,
+                "dns": list(policy.dns),
+            },
+        }
+
+    def _validate_execution_host(
+        self,
+        target: CloudHypervisorTarget,
+        paths: ExecutionPaths,
+        shares: list[_VirtioFsShare],
+    ) -> None:
+        if sys.platform != "linux":
+            raise RuntimeError("Cloud Hypervisor targets require a Linux host with KVM")
+        kvm = Path("/dev/kvm")
+        if not kvm.exists() or not os.access(kvm, os.R_OK | os.W_OK):
+            raise PermissionError(
+                "Cloud Hypervisor target requires read/write access to `/dev/kvm`"
+            )
+        kernel = self._resolve_host_path(target.kernel, paths)
+        if not kernel.is_file():
+            raise FileNotFoundError(
+                f"Cloud Hypervisor kernel does not exist or is not a file: {kernel}"
+            )
+        for share in shares:
+            if not share.source.is_dir():
+                raise FileNotFoundError(
+                    f"Cloud Hypervisor virtio-fs source does not exist or is not a directory: {share.source}"
+                )
+        for executable, field_name in (
+            (target.binary, "binary"),
+            (target.virtiofsd, "virtiofsd"),
+        ):
+            if os.path.sep in executable:
+                executable_path = Path(executable).expanduser()
+                if not executable_path.is_file() or not os.access(
+                    executable_path, os.X_OK
+                ):
+                    raise FileNotFoundError(
+                        f"`target.{field_name}` is not executable: {executable_path}"
+                    )
+            elif shutil.which(executable) is None:
+                raise FileNotFoundError(
+                    f"`target.{field_name}` executable was not found on PATH: {executable}"
+                )
+
+        self._validate_executable_features(
+            target.binary,
+            "cloud-hypervisor",
+            ("--api-socket", "--fs", "--vsock", "--seccomp"),
+        )
+        self._validate_executable_features(
+            target.virtiofsd,
+            "virtiofsd",
+            ("--readonly", "--translate-uid", "--translate-gid"),
+        )
+
+    def _validate_executable_features(
+        self,
+        executable: str,
+        label: str,
+        required_options: tuple[str, ...],
+    ) -> None:
+        try:
+            result = subprocess.run(
+                [executable, "--help"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise RuntimeError(
+                f"could not inspect {label} capabilities: {exc}"
+            ) from exc
+        help_text = f"{result.stdout}\n{result.stderr}"
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(
+                f"{label} --help failed with status {result.returncode}: {detail}"
+            )
+        missing = [option for option in required_options if option not in help_text]
+        if missing:
+            raise RuntimeError(
+                f"{label} is missing required options {missing}; install a current compatible release"
+            )
+
+    def _prepare_runtime(
+        self,
+        target: CloudHypervisorTarget,
+        prepared: PreparedExecution,
+        paths: ExecutionPaths,
+    ) -> dict[str, str]:
+        paths.host_runtime_dir.mkdir(parents=True, exist_ok=True)
+        paths.host_runtime_dir.chmod(0o700)
+        nss_files, nss_env = self._nss_runtime_files(target, paths)
+        collisions = sorted(set(prepared.runtime_files).intersection(nss_files))
+        if collisions:
+            raise ValueError(
+                f"adapter runtime files collide with Cloud Hypervisor NSS files: {collisions}"
+            )
+        self.materialize_runtime_files(
+            paths.host_runtime_dir, {**prepared.runtime_files, **nss_files}
+        )
+        self._materialize_inherited_credentials(target, prepared, paths)
+        home = paths.host_runtime_dir / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        home.chmod(0o700)
+        return nss_env
+
+    def _open_private_log(self, path: Path) -> BinaryIO:
+        if path.is_symlink():
+            path.unlink()
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_CLOEXEC
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags, 0o600)
+        try:
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                raise ValueError(
+                    f"Cloud Hypervisor log path is not a regular file: {path}"
+                )
+            os.fchmod(descriptor, 0o600)
+            if hasattr(os, "set_blocking"):
+                os.set_blocking(descriptor, True)
+            return os.fdopen(descriptor, "wb")
+        except Exception:
+            os.close(descriptor)
+            raise
+
+    async def _start_virtiofsd(
+        self,
+        target: CloudHypervisorTarget,
+        share: _VirtioFsShare,
+        guest_uid: int,
+        guest_gid: int,
+        log_path: Path,
+    ) -> asyncio.subprocess.Process:
+        log_handle = self._open_private_log(log_path)
+        try:
+            return await asyncio.create_subprocess_exec(
+                *self._virtiofsd_command(target, share, guest_uid, guest_gid),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        finally:
+            log_handle.close()
+
+    async def _wait_for_virtiofs_sockets(
+        self,
+        processes: list[asyncio.subprocess.Process],
+        shares: list[_VirtioFsShare],
+        timeout: float,
+        should_cancel: CancelCallback,
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while True:
+            if should_cancel():
+                raise asyncio.CancelledError
+            failed = next(
+                (process for process in processes if process.returncode is not None),
+                None,
+            )
+            if failed is not None:
+                raise RuntimeError(
+                    f"virtiofsd exited before Cloud Hypervisor launch with status {failed.returncode}"
+                )
+            if all(share.socket.exists() for share in shares):
+                return
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    "virtiofsd sockets were not ready before the boot timeout"
+                )
+            await asyncio.sleep(0.05)
+
+    async def _start_vmm(
+        self,
+        target: CloudHypervisorTarget,
+        paths: ExecutionPaths,
+        shares: list[_VirtioFsShare],
+    ) -> asyncio.subprocess.Process:
+        log_handle = self._open_private_log(
+            paths.host_runtime_dir / "cloud-hypervisor-vmm.log"
+        )
+        try:
+            return await asyncio.create_subprocess_exec(
+                *self._vmm_command(target, paths, shares),
+                cwd=str(paths.host_workdir),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        finally:
+            log_handle.close()
+
+    async def _connect_guest(
+        self,
+        target: CloudHypervisorTarget,
+        paths: ExecutionPaths,
+        vmm: asyncio.subprocess.Process,
+        should_cancel: CancelCallback,
+        deadline: float,
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        loop = asyncio.get_running_loop()
+        boot_deadline = min(deadline, loop.time() + target.boot_timeout_seconds)
+        vsock_path = self._socket_path(self._state_dir(paths), "vsock.sock")
+        last_connection_error: BaseException | None = None
+        while loop.time() < boot_deadline:
+            if should_cancel():
+                raise asyncio.CancelledError
+            if vmm.returncode is not None:
+                detail = (
+                    f"; last vsock connection error: {last_connection_error}"
+                    if last_connection_error is not None
+                    else ""
+                )
+                raise RuntimeError(
+                    f"cloud-hypervisor exited during guest boot with status {vmm.returncode}{detail}"
+                )
+            if not vsock_path.exists():
+                await asyncio.sleep(0.1)
+                continue
+            writer: asyncio.StreamWriter | None = None
+            try:
+                reader, writer = await asyncio.wait_for(
+                    asyncio.open_unix_connection(
+                        vsock_path, limit=_MAX_GUEST_EVENT_BYTES
+                    ),
+                    timeout=0.5,
+                )
+                writer.write(f"CONNECT {target.guest_agent_port}\n".encode("ascii"))
+                await writer.drain()
+                first_line = await asyncio.wait_for(reader.readline(), timeout=2.0)
+                if first_line.startswith(b"OK "):
+                    allocated_port = first_line[3:].strip()
+                    if not allocated_port.isdigit():
+                        raise ValueError(
+                            f"invalid Cloud Hypervisor vsock acknowledgement: {first_line!r}"
+                        )
+                    hello_line = await asyncio.wait_for(reader.readline(), timeout=2.0)
+                else:
+                    hello_line = first_line
+                hello = json.loads(hello_line)
+                if hello != {"event": "hello", "protocol": _PROTOCOL_VERSION}:
+                    raise ValueError(f"unexpected guest hello: {hello!r}")
+                return reader, writer
+            except (
+                ConnectionError,
+                OSError,
+                UnicodeDecodeError,
+                ValueError,
+                json.JSONDecodeError,
+                asyncio.TimeoutError,
+            ) as exc:
+                last_connection_error = exc
+                if writer is not None:
+                    writer.close()
+                    with suppress(Exception):
+                        await writer.wait_closed()
+                await asyncio.sleep(0.1)
+        if loop.time() >= deadline:
+            raise TimeoutError("Cloud Hypervisor node timed out while booting")
+        raise TimeoutError(
+            f"Cloud Hypervisor guest agent did not become ready within {target.boot_timeout_seconds}s"
+        )
+
+    async def _consume_guest(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        request: dict[str, Any],
+        on_output: StreamCallback,
+        should_cancel: CancelCallback,
+        deadline: float,
+    ) -> RawExecutionResult:
+        request_bytes = (
+            json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            )
+            + b"\n"
+        )
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        partial_lines: dict[str, list[str]] = {"stdout": [], "stderr": []}
+        partial_sizes = {"stdout": 0, "stderr": 0}
+        partial_open = {"stdout": False, "stderr": False}
+        if len(request_bytes) > _MAX_REQUEST_BYTES:
+            message = "Cloud Hypervisor guest request exceeds the 16 MiB protocol limit"
+            stderr_lines.append(message)
+            await on_output("stderr", message)
+            return RawExecutionResult(
+                exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+            )
+        try:
+            writer.write(request_bytes)
+            await writer.drain()
+        except (ConnectionError, OSError) as exc:
+            message = f"could not send Cloud Hypervisor guest request: {exc}"
+            stderr_lines.append(message)
+            await on_output("stderr", message)
+            return RawExecutionResult(
+                exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+            )
+        loop = asyncio.get_running_loop()
+        while True:
+            if should_cancel():
+                return RawExecutionResult(
+                    exit_code=130,
+                    stdout_lines=stdout_lines,
+                    stderr_lines=stderr_lines,
+                    cancelled=True,
+                )
+            if loop.time() >= deadline:
+                return RawExecutionResult(
+                    exit_code=124,
+                    stdout_lines=stdout_lines,
+                    stderr_lines=stderr_lines,
+                    timed_out=True,
+                )
+            try:
+                line = await asyncio.wait_for(reader.readline(), timeout=0.2)
+            except asyncio.TimeoutError:
+                continue
+            except (OSError, ValueError) as exc:
+                message = f"invalid Cloud Hypervisor guest protocol stream: {exc}"
+                stderr_lines.append(message)
+                await on_output("stderr", message)
+                return RawExecutionResult(
+                    exit_code=1,
+                    stdout_lines=stdout_lines,
+                    stderr_lines=stderr_lines,
+                )
+            if not line:
+                message = "Cloud Hypervisor guest agent disconnected before returning a result"
+                stderr_lines.append(message)
+                await on_output("stderr", message)
+                return RawExecutionResult(
+                    exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+                )
+            try:
+                event = json.loads(line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                message = f"invalid Cloud Hypervisor guest protocol event: {exc}"
+                stderr_lines.append(message)
+                await on_output("stderr", message)
+                return RawExecutionResult(
+                    exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+                )
+            if not isinstance(event, dict):
+                message = f"invalid Cloud Hypervisor guest protocol event: {event!r}"
+                stderr_lines.append(message)
+                await on_output("stderr", message)
+                return RawExecutionResult(
+                    exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+                )
+            event_name = event.get("event")
+            if event_name == "stream":
+                stream_name = event.get("stream")
+                text = event.get("text")
+                line_end = event.get("line_end", True)
+                if (
+                    stream_name not in {"stdout", "stderr"}
+                    or not isinstance(text, str)
+                    or not isinstance(line_end, bool)
+                ):
+                    message = f"invalid Cloud Hypervisor stream event: {event!r}"
+                    stderr_lines.append(message)
+                    await on_output("stderr", message)
+                    return RawExecutionResult(
+                        exit_code=1,
+                        stdout_lines=stdout_lines,
+                        stderr_lines=stderr_lines,
+                    )
+                fragments = partial_lines[stream_name]
+                fragments.append(text)
+                partial_sizes[stream_name] += len(text)
+                partial_open[stream_name] = not line_end
+                if (
+                    partial_sizes[stream_name] > _MAX_LOGICAL_STREAM_LINE_CHARS
+                    or len(fragments) > _MAX_STREAM_FRAGMENTS_PER_LINE
+                ):
+                    message = f"Cloud Hypervisor {stream_name} line exceeds the guest protocol limit"
+                    stderr_lines.append(message)
+                    await on_output("stderr", message)
+                    return RawExecutionResult(
+                        exit_code=1,
+                        stdout_lines=stdout_lines,
+                        stderr_lines=stderr_lines,
+                    )
+                if not line_end:
+                    continue
+                complete_line = "".join(fragments)
+                fragments.clear()
+                partial_sizes[stream_name] = 0
+                buffer = stdout_lines if stream_name == "stdout" else stderr_lines
+                buffer.append(complete_line)
+                await on_output(stream_name, complete_line)
+                continue
+            if event_name == "started":
+                if (
+                    not isinstance(event.get("pid"), int)
+                    or isinstance(event.get("pid"), bool)
+                    or event["pid"] <= 0
+                ):
+                    message = f"invalid Cloud Hypervisor started event: {event!r}"
+                    stderr_lines.append(message)
+                    await on_output("stderr", message)
+                    return RawExecutionResult(
+                        exit_code=1,
+                        stdout_lines=stdout_lines,
+                        stderr_lines=stderr_lines,
+                    )
+                continue
+            if event_name == "result":
+                if any(partial_open.values()):
+                    message = (
+                        "Cloud Hypervisor guest ended with an incomplete stream line"
+                    )
+                    stderr_lines.append(message)
+                    await on_output("stderr", message)
+                    return RawExecutionResult(
+                        exit_code=1,
+                        stdout_lines=stdout_lines,
+                        stderr_lines=stderr_lines,
+                    )
+                exit_code = event.get("exit_code")
+                if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+                    message = f"invalid Cloud Hypervisor result event: {event!r}"
+                    stderr_lines.append(message)
+                    await on_output("stderr", message)
+                    return RawExecutionResult(
+                        exit_code=1,
+                        stdout_lines=stdout_lines,
+                        stderr_lines=stderr_lines,
+                    )
+                return RawExecutionResult(
+                    exit_code=exit_code,
+                    stdout_lines=stdout_lines,
+                    stderr_lines=stderr_lines,
+                )
+            if event_name == "error":
+                message = str(
+                    event.get("message") or "Cloud Hypervisor guest agent failed"
+                )
+                stderr_lines.append(message)
+                await on_output("stderr", message)
+                return RawExecutionResult(
+                    exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+                )
+            message = f"invalid Cloud Hypervisor guest protocol event: {event!r}"
+            stderr_lines.append(message)
+            await on_output("stderr", message)
+            return RawExecutionResult(
+                exit_code=1, stdout_lines=stdout_lines, stderr_lines=stderr_lines
+            )
+
+    async def _request_vmm_shutdown(self, api_socket: Path) -> None:
+        if not api_socket.exists():
+            return
+        writer: asyncio.StreamWriter | None = None
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(api_socket), timeout=0.5
+            )
+            writer.write(
+                b"PUT /api/v1/vmm.shutdown HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: 0\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            await writer.drain()
+        except (ConnectionError, OSError, asyncio.TimeoutError):
+            pass
+        finally:
+            if writer is not None:
+                writer.close()
+                with suppress(Exception):
+                    await writer.wait_closed()
+
+    async def _stop_process(
+        self, process: asyncio.subprocess.Process, timeout: float
+    ) -> None:
+        if process.returncode is not None:
+            return
+        with suppress(ProcessLookupError):
+            process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=timeout)
+            return
+        except asyncio.TimeoutError:
+            pass
+        with suppress(ProcessLookupError):
+            process.kill()
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(process.wait(), timeout=1.0)
+
+    def _copy_console_log(self, paths: ExecutionPaths) -> None:
+        source = self._state_dir(paths) / "console.log"
+        destination = paths.host_runtime_dir / "cloud-hypervisor-console.log"
+        if source.is_file():
+            with (
+                source.open("rb") as source_handle,
+                self._open_private_log(destination) as destination_handle,
+            ):
+                shutil.copyfileobj(source_handle, destination_handle)
+
+    def _cleanup_state_dir(self, paths: ExecutionPaths) -> None:
+        state_dir = self._state_dir(paths)
+        if state_dir.is_symlink():
+            raise ValueError(
+                f"Cloud Hypervisor state directory must not be a symlink: {state_dir}"
+            )
+        if state_dir.exists():
+            if hasattr(os, "getuid") and state_dir.stat().st_uid != os.getuid():
+                raise PermissionError(
+                    f"refusing to remove Cloud Hypervisor state directory owned by another user: {state_dir}"
+                )
+            shutil.rmtree(state_dir)
+
+    def plan_execution(
+        self,
+        node: NodeSpec,
+        prepared: PreparedExecution,
+        paths: ExecutionPaths,
+    ) -> LaunchPlan:
+        target = self._target(node)
+        self._validate_credentials_policy(target, prepared)
+        shares = self._shares(target, paths)
+        guest_uid, guest_gid = self._effective_guest_ids(target)
+        nss_files, nss_env = self._nss_runtime_files(target, paths)
+        request = self._guest_request(target, prepared, shares, nss_env)
+        return LaunchPlan(
+            kind="cloud_hypervisor",
+            command=self._vmm_command(target, paths, shares),
+            env={},
+            cwd=str(paths.host_workdir),
+            stdin=None,
+            runtime_files=sorted(
+                set(prepared.runtime_files)
+                | set(prepared.runtime_symlinks)
+                | set(nss_files)
+            ),
+            payload={
+                "kernel": str(self._resolve_host_path(target.kernel, paths)),
+                "rootfs": str(self._resolve_host_path(target.rootfs, paths)),
+                "binary": target.binary,
+                "virtiofsd": target.virtiofsd,
+                "cpus": target.cpus,
+                "memory_mib": target.memory_mib,
+                "guest_user": f"{guest_uid}:{guest_gid}",
+                "vsock_cid": self._vsock_cid(target, paths),
+                "guest_agent_port": target.guest_agent_port,
+                "network_policy": target.network_policy.model_dump(mode="json"),
+                "inherit_credentials": target.inherit_credentials,
+                "env_keys": sorted(request["env"]),
+                "mounts": [
+                    {
+                        "tag": share.tag,
+                        "source": str(share.source),
+                        "target": share.target or "/",
+                        "read_only": share.read_only,
+                    }
+                    for share in shares
+                ],
+                "virtiofsd_commands": [
+                    self._virtiofsd_command(target, share, guest_uid, guest_gid)
+                    for share in shares
+                ],
+            },
+        )
+
+    async def execute(
+        self,
+        node: NodeSpec,
+        prepared: PreparedExecution,
+        paths: ExecutionPaths,
+        on_output: StreamCallback,
+        should_cancel: CancelCallback,
+    ) -> RawExecutionResult:
+        try:
+            target = self._target(node)
+            self._validate_credentials_policy(target, prepared)
+            shares = self._shares(target, paths)
+            self._validate_execution_host(target, paths, shares)
+            nss_env = self._prepare_runtime(target, prepared, paths)
+            self._cleanup_state_dir(paths)
+            state_dir = self._state_dir(paths)
+            state_dir.mkdir(mode=0o700)
+        except (OSError, RuntimeError, ValueError) as exc:
+            message = f"Cloud Hypervisor launch validation failed: {exc}"
+            await on_output("stderr", message)
+            return RawExecutionResult(exit_code=1, stderr_lines=[message])
+
+        guest_uid, guest_gid = self._effective_guest_ids(target)
+        virtiofsd_processes: list[asyncio.subprocess.Process] = []
+        vmm: asyncio.subprocess.Process | None = None
+        writer: asyncio.StreamWriter | None = None
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + node.timeout_seconds
+        try:
+            for index, share in enumerate(shares):
+                process = await self._start_virtiofsd(
+                    target,
+                    share,
+                    guest_uid,
+                    guest_gid,
+                    paths.host_runtime_dir / f"virtiofsd-{index:03d}.log",
+                )
+                virtiofsd_processes.append(process)
+            await self._wait_for_virtiofs_sockets(
+                virtiofsd_processes,
+                shares,
+                min(
+                    float(target.boot_timeout_seconds), max(0.1, deadline - loop.time())
+                ),
+                should_cancel,
+            )
+            vmm = await self._start_vmm(target, paths, shares)
+            reader, writer = await self._connect_guest(
+                target, paths, vmm, should_cancel, deadline
+            )
+            request = self._guest_request(target, prepared, shares, nss_env)
+            return await self._consume_guest(
+                reader, writer, request, on_output, should_cancel, deadline
+            )
+        except asyncio.CancelledError:
+            return RawExecutionResult(exit_code=130, cancelled=True)
+        except TimeoutError as exc:
+            message = str(exc)
+            await on_output("stderr", message)
+            return RawExecutionResult(
+                exit_code=124, stderr_lines=[message], timed_out=True
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            message = f"Cloud Hypervisor launch failed: {exc}"
+            await on_output("stderr", message)
+            return RawExecutionResult(exit_code=1, stderr_lines=[message])
+        finally:
+            if writer is not None:
+                writer.close()
+                with suppress(Exception):
+                    await writer.wait_closed()
+            if vmm is not None:
+                await self._request_vmm_shutdown(
+                    self._socket_path(state_dir, "api.sock")
+                )
+                try:
+                    await asyncio.wait_for(
+                        vmm.wait(), timeout=target.shutdown_timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    await self._stop_process(vmm, target.shutdown_timeout_seconds)
+            if virtiofsd_processes:
+                await asyncio.gather(
+                    *(
+                        self._stop_process(process, target.shutdown_timeout_seconds)
+                        for process in reversed(virtiofsd_processes)
+                    ),
+                    return_exceptions=True,
+                )
+            try:
+                with suppress(OSError, ValueError):
+                    self._copy_console_log(paths)
+            finally:
+                self._cleanup_state_dir(paths)

--- a/agentflow/runners/registry.py
+++ b/agentflow/runners/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from agentflow.runners.base import Runner
+from agentflow.runners.cloud_hypervisor import CloudHypervisorRunner
 from agentflow.runners.container import ContainerRunner
 from agentflow.runners.docker import DockerRunner
 from agentflow.runners.ec2 import EC2Runner
@@ -15,6 +16,7 @@ class RunnerRegistry:
             "local": LocalRunner(),
             "container": ContainerRunner(),
             "docker": DockerRunner(),
+            "cloud_hypervisor": CloudHypervisorRunner(),
             "ssh": SSHRunner(),
             "ec2": EC2Runner(),
             "ecs": ECSRunner(),

--- a/agentflow/specs.py
+++ b/agentflow/specs.py
@@ -884,6 +884,411 @@ class DockerTarget(BaseModel):
         return self
 
 
+class CloudHypervisorMount(BaseModel):
+    """A host directory shared with a Cloud Hypervisor guest through virtio-fs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    target: str
+    read_only: bool = True
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("`target.mounts[].source` must not be empty")
+        if "\x00" in normalized:
+            raise ValueError("`target.mounts[].source` must not contain NUL bytes")
+        return normalized
+
+    @field_validator("target")
+    @classmethod
+    def validate_target(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized.startswith("/"):
+            raise ValueError("`target.mounts[].target` must be an absolute guest path")
+        if normalized.startswith("//"):
+            raise ValueError("`target.mounts[].target` must use a single leading slash")
+        if "\x00" in normalized or "," in normalized:
+            raise ValueError(
+                "`target.mounts[].target` must not contain NUL bytes or commas"
+            )
+        return posixpath.normpath(normalized)
+
+
+class CloudHypervisorNetworkPolicy(BaseModel):
+    """Network attachment and guest configuration for a Cloud Hypervisor VM."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["none", "tap"] = "none"
+    tap: str | None = None
+    mac: str | None = None
+    host_ip: str | None = None
+    host_mask: str | None = None
+    dhcp: bool = False
+    guest_address: str | None = None
+    gateway: str | None = None
+    dns: list[str] = Field(default_factory=list)
+    num_queues: int = Field(default=2, ge=2, le=256)
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_shorthand(cls, data: Any) -> Any:
+        if isinstance(data, str):
+            normalized = data.strip()
+            if normalized == "none":
+                return {"mode": "none"}
+            if normalized == "tap":
+                return {
+                    "mode": "tap",
+                    "host_ip": "192.168.249.1",
+                    "host_mask": "255.255.255.0",
+                    "guest_address": "192.168.249.2/24",
+                    "gateway": "192.168.249.1",
+                }
+            if normalized:
+                return {"mode": "tap", "tap": normalized, "dhcp": True}
+            raise ValueError("`target.network_policy` must not be empty")
+        return data
+
+    @field_validator("tap")
+    @classmethod
+    def validate_tap(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            return None
+        if not re.fullmatch(r"[A-Za-z0-9_.-]{1,15}", normalized):
+            raise ValueError(
+                "`target.network_policy.tap` must be a Linux interface name of at most 15 characters"
+            )
+        return normalized
+
+    @field_validator("mac")
+    @classmethod
+    def validate_mac(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{2}(?::[0-9a-f]{2}){5}", normalized):
+            raise ValueError(
+                "`target.network_policy.mac` must be a colon-separated MAC address"
+            )
+        return normalized
+
+    @field_validator("host_ip", "gateway")
+    @classmethod
+    def validate_ip_address(cls, value: str | None, info) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        try:
+            address = ipaddress.ip_address(normalized)
+        except ValueError as exc:
+            raise ValueError(
+                f"`target.network_policy.{info.field_name}` must be an IP address"
+            ) from exc
+        if info.field_name == "host_ip" and address.version != 4:
+            raise ValueError("`target.network_policy.host_ip` must be an IPv4 address")
+        return str(address)
+
+    @field_validator("host_mask")
+    @classmethod
+    def validate_host_mask(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        try:
+            address = ipaddress.IPv4Address(normalized)
+            ipaddress.IPv4Network(f"0.0.0.0/{address}")
+        except ValueError as exc:
+            raise ValueError(
+                "`target.network_policy.host_mask` must be a contiguous IPv4 netmask"
+            ) from exc
+        return str(address)
+
+    @field_validator("guest_address")
+    @classmethod
+    def validate_guest_address(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        try:
+            address = ipaddress.ip_interface(normalized)
+        except ValueError as exc:
+            raise ValueError(
+                "`target.network_policy.guest_address` must be an IP interface in CIDR form"
+            ) from exc
+        return str(address)
+
+    @field_validator("dns")
+    @classmethod
+    def validate_dns(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for entry in value:
+            try:
+                normalized.append(str(ipaddress.ip_address(entry.strip())))
+            except ValueError as exc:
+                raise ValueError(
+                    "`target.network_policy.dns` entries must be IP addresses"
+                ) from exc
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("`target.network_policy.dns` entries must be unique")
+        return normalized
+
+    @field_validator("num_queues")
+    @classmethod
+    def validate_num_queues(cls, value: int) -> int:
+        if value % 2:
+            raise ValueError("`target.network_policy.num_queues` must be even")
+        return value
+
+    @model_validator(mode="after")
+    def validate_mode(self) -> CloudHypervisorNetworkPolicy:
+        configured = any(
+            (
+                self.tap is not None,
+                self.mac is not None,
+                self.host_ip is not None,
+                self.host_mask is not None,
+                self.dhcp,
+                self.guest_address is not None,
+                self.gateway is not None,
+                bool(self.dns),
+                self.num_queues != 2,
+            )
+        )
+        if self.mode == "none" and configured:
+            raise ValueError(
+                "Cloud Hypervisor network settings require `target.network_policy.mode: tap`"
+            )
+        if (self.host_ip is None) != (self.host_mask is None):
+            raise ValueError("`host_ip` and `host_mask` must be configured together")
+        if self.dhcp and self.guest_address is not None:
+            raise ValueError("`dhcp` and `guest_address` are mutually exclusive")
+        if self.gateway is not None and self.guest_address is None:
+            raise ValueError("`gateway` requires a static `guest_address`")
+        if self.guest_address is not None and self.gateway is not None:
+            guest_version = ipaddress.ip_interface(self.guest_address).version
+            gateway_version = ipaddress.ip_address(self.gateway).version
+            if guest_version != gateway_version:
+                raise ValueError(
+                    "`guest_address` and `gateway` must use the same IP version"
+                )
+        if (
+            self.host_ip is not None
+            and self.guest_address is not None
+            and ipaddress.ip_interface(self.guest_address).version != 4
+        ):
+            raise ValueError(
+                "`host_ip` and `guest_address` must use the same IP version"
+            )
+        return self
+
+
+_CLOUD_HYPERVISOR_SYSTEM_PATHS = ("/dev", "/proc", "/run", "/sys")
+
+
+class CloudHypervisorTarget(BaseModel):
+    """Boot an ephemeral AgentFlow guest with Cloud Hypervisor and virtio-fs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["cloud_hypervisor"] = "cloud_hypervisor"
+    kernel: str
+    rootfs: str
+    binary: str = "cloud-hypervisor"
+    virtiofsd: str = "virtiofsd"
+    cpus: int = Field(default=2, ge=1, le=256)
+    memory_mib: int = Field(default=4096, ge=256)
+    workdir_mount: str = "/workspace"
+    runtime_mount: str = "/agentflow-runtime"
+    app_mount: str | None = None
+    workdir_read_only: bool = False
+    user: str | None = "host"
+    inherit_credentials: bool = False
+    mounts: list[CloudHypervisorMount] = Field(default_factory=list)
+    network_policy: CloudHypervisorNetworkPolicy = Field(
+        default_factory=CloudHypervisorNetworkPolicy
+    )
+    guest_agent_port: int = Field(default=4050, ge=1, le=65535)
+    vsock_cid: int | None = Field(default=None, ge=3, le=4_294_967_294)
+    boot_timeout_seconds: int = Field(default=60, ge=1, le=3600)
+    shutdown_timeout_seconds: float = Field(default=5.0, ge=0.1, le=60.0)
+    init_path: str = "/usr/local/bin/agentflow-cloud-hypervisor-init"
+    nss_wrapper_path: str | None = "/usr/lib/libnss_wrapper.so"
+    kernel_args: list[str] = Field(default_factory=list)
+    seccomp: Literal["true", "false", "log"] = "true"
+
+    @field_validator("kernel", "rootfs", "binary", "virtiofsd")
+    @classmethod
+    def validate_required_text(cls, value: str, info) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"`target.{info.field_name}` must not be empty")
+        if "\x00" in normalized:
+            raise ValueError(f"`target.{info.field_name}` must not contain NUL bytes")
+        if (
+            info.field_name in {"binary", "virtiofsd"}
+            and "/" in normalized
+            and not Path(normalized).is_absolute()
+        ):
+            raise ValueError(
+                f"`target.{info.field_name}` must be a PATH executable name or an absolute host path"
+            )
+        return normalized
+
+    @field_validator("workdir_mount", "runtime_mount")
+    @classmethod
+    def validate_required_guest_path(cls, value: str, info) -> str:
+        normalized = value.strip()
+        if not normalized.startswith("/"):
+            raise ValueError(
+                f"`target.{info.field_name}` must be an absolute guest path"
+            )
+        if normalized.startswith("//"):
+            raise ValueError(
+                f"`target.{info.field_name}` must use a single leading slash"
+            )
+        if "\x00" in normalized or "," in normalized:
+            raise ValueError(
+                f"`target.{info.field_name}` must not contain NUL bytes or commas"
+            )
+        if info.field_name == "runtime_mount" and any(
+            character in normalized for character in (":", "\r", "\n")
+        ):
+            raise ValueError(
+                "`target.runtime_mount` must not contain colons or line breaks because it is used in the guest passwd file"
+            )
+        return posixpath.normpath(normalized)
+
+    @field_validator("app_mount")
+    @classmethod
+    def validate_optional_guest_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized.startswith("/"):
+            raise ValueError(
+                "`target.app_mount` must be an absolute guest path or null"
+            )
+        if normalized.startswith("//"):
+            raise ValueError("`target.app_mount` must use a single leading slash")
+        if "\x00" in normalized or "," in normalized:
+            raise ValueError("`target.app_mount` must not contain NUL bytes or commas")
+        return posixpath.normpath(normalized)
+
+    @field_validator("init_path")
+    @classmethod
+    def validate_init_path(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized.startswith("/") or normalized.startswith("//"):
+            raise ValueError("`target.init_path` must be an absolute guest path")
+        if "\x00" in normalized or any(character.isspace() for character in normalized):
+            raise ValueError(
+                "`target.init_path` must not contain whitespace or NUL bytes"
+            )
+        return posixpath.normpath(normalized)
+
+    @field_validator("nss_wrapper_path")
+    @classmethod
+    def validate_nss_wrapper_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized.startswith("/") or normalized.startswith("//"):
+            raise ValueError(
+                "`target.nss_wrapper_path` must be an absolute guest path or null"
+            )
+        if "\x00" in normalized or any(character.isspace() for character in normalized):
+            raise ValueError(
+                "`target.nss_wrapper_path` must not contain whitespace or NUL bytes"
+            )
+        return posixpath.normpath(normalized)
+
+    @field_validator("user")
+    @classmethod
+    def validate_user(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if normalized in {"host", "root", "0", "0:0"}:
+            return normalized
+        if not re.fullmatch(r"[0-9]+(?::[0-9]+)?", normalized):
+            raise ValueError(
+                "`target.user` must be `host`, `root`, a numeric UID[:GID], or null"
+            )
+        if any(int(identifier) > 4_294_967_294 for identifier in normalized.split(":")):
+            raise ValueError(
+                "`target.user` UID and GID must fit Linux 32-bit identifiers"
+            )
+        return normalized
+
+    @field_validator("kernel_args")
+    @classmethod
+    def validate_kernel_args(cls, value: list[str]) -> list[str]:
+        normalized = [argument.strip() for argument in value]
+        if any(not argument for argument in normalized):
+            raise ValueError("`target.kernel_args` entries must not be empty")
+        if any(
+            "\x00" in argument or any(character.isspace() for character in argument)
+            for argument in normalized
+        ):
+            raise ValueError(
+                "`target.kernel_args` entries must be single arguments without whitespace or NUL bytes"
+            )
+        protected_prefixes = (
+            "agentflow.guest_port=",
+            "init=",
+            "root=",
+            "rootflags=",
+            "rootfstype=",
+        )
+        if any(
+            argument in {"--", "ro", "rw"} or argument.startswith(protected_prefixes)
+            for argument in normalized
+        ):
+            raise ValueError(
+                "`target.kernel_args` cannot override AgentFlow's root filesystem or guest init"
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_mount_layout(self) -> CloudHypervisorTarget:
+        managed_targets = [self.workdir_mount, self.runtime_mount]
+        if self.app_mount is not None:
+            managed_targets.append(self.app_mount)
+
+        all_static_targets = [
+            *managed_targets,
+            *(mount.target for mount in self.mounts),
+        ]
+        for target in all_static_targets:
+            for system_path in _CLOUD_HYPERVISOR_SYSTEM_PATHS:
+                if _docker_container_paths_overlap(target, system_path):
+                    raise ValueError(
+                        f"Cloud Hypervisor guest mount target `{target}` overlaps reserved system path `{system_path}`"
+                    )
+
+        overlaps = sorted(
+            (left, right)
+            for index, left in enumerate(all_static_targets)
+            for right in all_static_targets[index + 1 :]
+            if _docker_container_paths_overlap(left, right)
+        )
+        if overlaps:
+            rendered = ", ".join(f"{left} <> {right}" for left, right in overlaps)
+            raise ValueError(
+                "Cloud Hypervisor guest mount targets must not overlap as ancestors or descendants: "
+                + rendered
+            )
+        return self
+
+
 class SSHTarget(BaseModel):
     """Remote execution via SSH."""
 
@@ -940,7 +1345,7 @@ class ECSTarget(BaseModel):
 
 
 TargetSpec = Annotated[
-    LocalTarget | ContainerTarget | DockerTarget | SSHTarget | EC2Target | ECSTarget,
+    LocalTarget | ContainerTarget | DockerTarget | CloudHypervisorTarget | SSHTarget | EC2Target | ECSTarget,
     Field(discriminator="kind"),
 ]
 

--- a/cloud_hypervisor/export-rootfs.sh
+++ b/cloud_hypervisor/export-rootfs.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+image="${1:-agentflow-agents:latest}"
+destination="${2:-}"
+
+if [ -z "$destination" ]; then
+    echo "usage: $0 [image] DESTINATION" >&2
+    exit 64
+fi
+if [ -e "$destination" ]; then
+    echo "destination already exists: $destination" >&2
+    exit 73
+fi
+
+mkdir -m 0755 -- "$destination"
+container_id=""
+completed=false
+cleanup() {
+    if [ -n "$container_id" ]; then
+        docker rm "$container_id" >/dev/null 2>&1 || true
+    fi
+    if [ "$completed" != true ]; then
+        rm -rf -- "$destination"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+container_id="$(docker create "$image")"
+
+docker export "$container_id" | tar --no-same-owner -x -C "$destination"
+
+test -x "$destination/usr/local/bin/agentflow-cloud-hypervisor-init"
+test -L "$destination/opt/agentflow-venv/bin/python3"
+find "$destination/opt/uv-python" \
+    -type f \
+    -path '*/bin/python3.13' \
+    -perm -0100 \
+    -print -quit | grep -q .
+
+completed=true
+echo "exported $image to $destination"

--- a/cloud_hypervisor/guest-init.sh
+++ b/cloud_hypervisor/guest-init.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -u
+
+export PATH="/opt/agentflow-venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export IS_SANDBOX=1
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONUNBUFFERED=1
+
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sysfs /sys 2>/dev/null || true
+mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+mount -t tmpfs -o mode=0755,nosuid,nodev tmpfs /run 2>/dev/null || true
+mount -t tmpfs -o mode=1777,nosuid,nodev tmpfs /tmp 2>/dev/null || true
+
+guest_port=4050
+for kernel_argument in $(cat /proc/cmdline 2>/dev/null || true); do
+    case "$kernel_argument" in
+        agentflow.guest_port=*) guest_port="${kernel_argument#agentflow.guest_port=}" ;;
+    esac
+done
+
+case "$guest_port" in
+    '' | *[!0-9]*)
+        echo "agentflow-cloud-hypervisor-init: invalid guest port: $guest_port" >&2
+        guest_status=64
+        ;;
+    *)
+        python3 -m agentflow.cloud_hypervisor_guest --port "$guest_port"
+        guest_status=$?
+        ;;
+esac
+
+sync || true
+poweroff -f 2>/dev/null || reboot -f 2>/dev/null || true
+exit "$guest_status"

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -552,6 +552,246 @@ structured mounts or network policy, read-only workspaces, privilege control,
 host-daemon mounting, or DinD. The two kinds remain distinct so the stricter
 Docker-target validation does not silently change legacy container launches.
 
+### Cloud Hypervisor
+
+`kind: "cloud_hypervisor"` launches one ephemeral KVM virtual machine per node
+with [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor).
+The target uses direct kernel boot and a read-only virtio-fs root filesystem,
+not a mutable VM disk. The host sends the prepared command over virtio-vsock;
+the guest agent mounts the workspace/runtime shares and multiplexes stdout and
+stderr back over the same connection. It does not depend on SSH, an IP address,
+or a guest login account.
+
+#### Host and guest prerequisites
+
+The execution host must be Linux and provide:
+
+- read/write access to `/dev/kvm`;
+- a `cloud-hypervisor` executable;
+- a current [Rust `virtiofsd`](https://gitlab.com/virtio-fs/virtiofsd)
+  supporting `--readonly`, `--translate-uid`, and `--translate-gid`;
+- a Cloud Hypervisor-compatible kernel with built-in virtio-fs and vsock
+  support; and
+- an exported rootfs containing
+  `/usr/local/bin/agentflow-cloud-hypervisor-init` and the desired agent CLIs.
+
+The bundled Docker image contains the guest init, guest agent, Codex, Claude,
+Kimi, Pi, Docker CLI, Python, NSS wrapper, and common shell tooling. Build and
+export it without preserving container root ownership:
+
+```bash
+docker build -t agentflow-agents:latest .
+mkdir -p .agentflow/cloud-hypervisor
+cloud_hypervisor/export-rootfs.sh \
+  agentflow-agents:latest .agentflow/cloud-hypervisor/rootfs
+```
+
+For example, download the x86-64 kernel published by the Cloud Hypervisor
+project's kernel repository:
+
+```bash
+curl -fL \
+  https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/vmlinux-x86_64 \
+  -o .agentflow/cloud-hypervisor/vmlinux-x86_64
+```
+
+The kernel and rootfs architecture must match the host architecture. The
+current target is a Linux/KVM direct-kernel transport; it does not implement
+UEFI/disk-image boot or macOS virtualization.
+
+#### Configuration
+
+```python
+target={
+    "kind": "cloud_hypervisor",
+    "kernel": ".agentflow/cloud-hypervisor/vmlinux-x86_64",
+    "rootfs": ".agentflow/cloud-hypervisor/rootfs",
+    "cpus": 4,
+    "memory_mib": 8192,
+    "workdir_read_only": True,
+    "mounts": [
+        {"source": "./fixtures", "target": "/inputs", "read_only": True},
+    ],
+    "network_policy": "none",
+}
+```
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `kind` | required | Set to `cloud_hypervisor`. |
+| `kernel` | required | Host path to a direct-boot Cloud Hypervisor kernel. Relative paths resolve from pipeline `working_dir`. |
+| `rootfs` | required | Host directory exported as the immutable virtio-fs guest root. Relative paths resolve from pipeline `working_dir`. |
+| `binary` | `cloud-hypervisor` | Host Cloud Hypervisor executable. |
+| `virtiofsd` | `virtiofsd` | Host Rust virtiofsd executable. |
+| `cpus` | `2` | Boot vCPU count. |
+| `memory_mib` | `4096` | Guest memory in MiB. Shared memory is always enabled because virtio-fs requires it. |
+| `workdir_mount` | `/workspace` | Guest path for the pipeline workspace. |
+| `runtime_mount` | `/agentflow-runtime` | Guest path for private per-node runtime files and HOME. |
+| `app_mount` | `null` | Optional read-only guest path for the host AgentFlow source tree. The exported rootfs already contains AgentFlow. |
+| `workdir_read_only` | `false` | Export the host workspace through read-only virtiofsd and mount it read-only in the guest. |
+| `mounts` | `[]` | Additional directory shares with host `source`, absolute guest `target`, and `read_only` (default `true`). |
+| `user` | `host` | Run the agent command under the invoking host UID:GID. Also accepts `root`, numeric `UID[:GID]`, or `null` for root. virtiofsd maps that guest identity back to the invoking host identity. |
+| `inherit_credentials` | `false` | Permit adapters to copy selected host credential/config files into the private runtime share. Codex uses this for its config/login files. |
+| `network_policy` | `none` | No NIC, or a structured TAP attachment described below. |
+| `guest_agent_port` | `4050` | AF_VSOCK port used by the preinstalled guest agent. |
+| `vsock_cid` | derived | Optional explicit CID. The default is deterministically derived from the per-node runtime path. |
+| `boot_timeout_seconds` | `60` | Maximum wait for virtiofsd, VM boot, and guest-agent readiness. The node timeout still bounds the entire operation. |
+| `shutdown_timeout_seconds` | `5` | Grace period before force-killing VMM/backend processes. |
+| `init_path` | `/usr/local/bin/agentflow-cloud-hypervisor-init` | PID 1 path in the exported rootfs. |
+| `nss_wrapper_path` | `/usr/lib/libnss_wrapper.so` | Guest library used to resolve arbitrary numeric host UIDs. Set `null` only when the rootfs already resolves the selected user. |
+| `kernel_args` | `[]` | Additional single kernel arguments. Root filesystem, init, and protocol arguments cannot be overridden. |
+| `seccomp` | `true` | Cloud Hypervisor seccomp mode: `true`, `log`, or `false`. Disabling it weakens the host-side VMM sandbox. |
+
+#### Filesystem and identity model
+
+AgentFlow starts one independently sandboxed virtiofsd process for each share:
+
+| Host directory | Guest path | Access |
+| --- | --- | --- |
+| Exported all-agent rootfs | `/` | Always daemon-enforced read-only |
+| Pipeline `working_dir` | `workdir_mount` | Read/write unless `workdir_read_only: true` |
+| Per-run/per-node runtime | `runtime_mount` | Read/write |
+| Local AgentFlow source | `app_mount` | Optional and read-only |
+| Each configured `mounts[]` source | Configured target | Read-only by default |
+
+All guest mount points must already exist in the read-only rootfs. The bundled
+image creates `/workspace`, `/agentflow-runtime`, `/agentflow-app`, `/inputs`,
+`/outputs`, and `/reference`; custom targets should be created while building
+the image. Target paths cannot duplicate or be ancestors/descendants of one
+another and cannot overlap `/dev`, `/proc`, `/run`, or `/sys`.
+
+Read-only access is enforced twice: virtiofsd receives `--readonly`, and the
+guest mount uses `ro`. Canonical host-path checks prevent a read-only workspace,
+app, rootfs, or additional share from being reachable through an overlapping
+writable export. Likewise, a custom read-only share cannot alias the writable
+workspace or runtime under a second path.
+
+If the exported rootfs lives below the pipeline workspace (as in the relative
+quick-start path above), the workspace must be read-only. For a writable
+workspace, place the rootfs outside it, for example under
+`/opt/agentflow-vm/rootfs`. The writable run directory must never overlap the
+rootfs. An explicit read-only `app_mount` likewise cannot alias a writable
+workspace; omit it when the bundled rootfs copy of AgentFlow is sufficient.
+
+The command defaults to the host numeric UID:GID. virtiofsd translates that
+guest identity to the invoking host identity, so writable shares do not retain
+guest-root-owned files. A private NSS wrapper passwd/group pair is generated
+under the mode-`0700` runtime directory so Python, SSH, and agent CLIs can
+resolve the numeric user. Adapter-generated files and copied credentials use
+mode `0600`. The PID-1 guest agent invokes the privilege-drop helper by an
+absolute trusted-rootfs path with an empty environment, then installs the
+prepared command environment only after changing UID/GID; a command-controlled
+`PATH` or dynamic-loader variable therefore cannot replace or inject into the
+root privilege-drop process.
+
+#### Network policy
+
+The default creates no network device:
+
+```python
+target={
+    "kind": "cloud_hypervisor",
+    "kernel": KERNEL,
+    "rootfs": ROOTFS,
+    "network_policy": "none",
+}
+```
+
+The shorthand `"tap"` asks Cloud Hypervisor to create a TAP with host address
+`192.168.249.1/24` and configures the guest as `192.168.249.2/24`; creating the
+interface requires `CAP_NET_ADMIN`. Any other shorthand string is treated as
+the name of a pre-created TAP and uses DHCP in the guest, for example
+`"network_policy": "agenttap0"`. DHCP-provided DNS is installed from the
+guest's writable `/run` filesystem, so it also works with the immutable rootfs;
+an explicit `dns` list replaces those nameservers.
+
+To attach a pre-created TAP and use DHCP inside the guest:
+
+```python
+"network_policy": {
+    "mode": "tap",
+    "tap": "agenttap0",
+    "dhcp": True,
+    "dns": ["1.1.1.1"],
+}
+```
+
+For the default single RX/TX queue pair (`num_queues: 2`), create a persistent
+TAP with virtio-net headers enabled and grant the AgentFlow host user access to
+it. For example:
+
+```bash
+sudo ip tuntap add dev agenttap0 mode tap user "$(id -un)" vnet_hdr
+sudo ip link set agenttap0 up
+```
+
+Do not add `multi_queue` for the default queue count: Cloud Hypervisor opens a
+single TAP file descriptor in that configuration, and Linux rejects attaching
+it to a TAP that was created as multi-queue. When `num_queues` is greater than
+`2`, create the TAP with both `vnet_hdr` and `multi_queue`.
+
+Static guest configuration and an optional Cloud Hypervisor-created TAP use:
+
+```python
+"network_policy": {
+    "mode": "tap",
+    # null asks Cloud Hypervisor to create a TAP and requires CAP_NET_ADMIN.
+    "tap": None,
+    "host_ip": "192.168.249.1",
+    "host_mask": "255.255.255.0",
+    "guest_address": "192.168.249.2/24",
+    "gateway": "192.168.249.1",
+    "dns": ["1.1.1.1"],
+    "num_queues": 2,
+}
+```
+
+`host_ip` and `host_mask` configure Cloud Hypervisor's host side and are IPv4
+only. `guest_address` and `gateway` may use IPv4 or IPv6 when the pre-created
+TAP supports it, and they must use the same address family. `num_queues`
+defaults to `2` and must be an even number.
+
+The target does not create NAT, IP forwarding, DHCP servers, firewall rules, or
+an egress allowlist. A TAP connects the guest to networking configured by the
+operator. Enforce domain/IP/port policy on the host bridge/firewall or through
+a controlled egress gateway. The vsock control path remains available when the
+network policy is `none`.
+
+#### Credentials, lifecycle, and failure artifacts
+
+Host environment variables and CLI homes are not inherited implicitly. Values
+resolved into `node.env` or `provider.env` are sent in the in-memory vsock
+request and never placed in the VMM or virtiofsd argument lists. Inspection
+shows only environment keys and redacts all prepared values.
+
+`inherit_credentials: true` is an explicit trust decision. Unlike the Docker
+target's nested read-only bind mounts, the VM runner copies adapter-selected
+files into its private runtime share so host paths are never exposed through a
+symlink. Copies remain mode `0600`.
+
+The configured kernel, rootfs, `cloud-hypervisor`, `virtiofsd`, and mount
+sources are trusted host-side inputs. A writable share deliberately grants the
+guest command write access to that host directory. `use_worktree` currently
+applies only to local targets, so concurrent Cloud Hypervisor nodes share the
+same pipeline workspace unless their pipeline configuration points at separate
+directories.
+
+On success, failure, cancellation, or timeout AgentFlow requests VMM shutdown,
+then terminates and finally kills Cloud Hypervisor and every virtiofsd process
+if necessary. Unix API/vsock/backend sockets live in a private host temporary
+directory outside the guest-visible runtime share and are removed afterward.
+The runtime retains `cloud-hypervisor-vmm.log`,
+`cloud-hypervisor-console.log`, and per-share `virtiofsd-NNN.log` files for
+diagnosis; they do not contain the command environment or credential values.
+
+Run the credential-free smoke example with:
+
+```bash
+AGENTFLOW_CH_KERNEL=.agentflow/cloud-hypervisor/vmlinux-x86_64 \
+AGENTFLOW_CH_ROOTFS=.agentflow/cloud-hypervisor/rootfs \
+agentflow run examples/cloud_hypervisor_target.py --output summary
+```
+
 ### Container
 
 The legacy container target wraps the command in `docker run`, mounts the

--- a/examples/cloud_hypervisor_target.py
+++ b/examples/cloud_hypervisor_target.py
@@ -1,0 +1,57 @@
+"""Credential-free smoke pipeline for the Cloud Hypervisor target.
+
+Prepare a Cloud Hypervisor kernel and exported AgentFlow rootfs first, then set:
+
+    AGENTFLOW_CH_KERNEL=/opt/agentflow-vm/vmlinux-x86_64
+    AGENTFLOW_CH_ROOTFS=/opt/agentflow-vm/rootfs
+
+The target defaults to no network device. Set ``AGENTFLOW_CH_TAP`` to attach a
+pre-created TAP interface; guest address/routing should then be supplied in the
+target configuration for that host network.
+"""
+
+from __future__ import annotations
+
+import os
+
+from agentflow import Graph, shell
+
+KERNEL = os.environ.get(
+    "AGENTFLOW_CH_KERNEL", ".agentflow/cloud-hypervisor/vmlinux-x86_64"
+)
+ROOTFS = os.environ.get("AGENTFLOW_CH_ROOTFS", ".agentflow/cloud-hypervisor/rootfs")
+TAP = os.environ.get("AGENTFLOW_CH_TAP", "").strip()
+
+network_policy: str | dict[str, object]
+if TAP:
+    network_policy = {
+        "mode": "tap",
+        "tap": TAP,
+        "dhcp": True,
+    }
+else:
+    network_policy = "none"
+
+with Graph("cloud-hypervisor-smoke", working_dir="..") as dag:
+    shell(
+        task_id="vm_smoke",
+        script=r"""
+set -eu
+for executable in agentflow codex claude kimi pi docker; do
+    printf '%-10s %s\n' "$executable" "$(command -v "$executable")"
+done
+python3 -c 'import os, pwd; print("guest user", pwd.getpwuid(os.getuid()).pw_name, os.getuid(), os.getgid())'
+test -f README.md
+test -w "$HOME"
+printf 'cloud-hypervisor target is ready\n'
+""",
+        target={
+            "kind": "cloud_hypervisor",
+            "kernel": KERNEL,
+            "rootfs": ROOTFS,
+            "workdir_read_only": True,
+            "network_policy": network_policy,
+        },
+    )
+
+print(dag.to_json())

--- a/tests/test_cloud_hypervisor_target.py
+++ b/tests/test_cloud_hypervisor_target.py
@@ -1,0 +1,1434 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agentflow.agents.codex import CodexAdapter
+from agentflow.cloud_hypervisor_guest import (
+    GuestRequestError,
+    _command_for_identity,
+    _configure_dhcp,
+    _configure_network,
+    _execute_request,
+    _validate_mounts,
+    _validate_request,
+)
+from agentflow.inspection import build_launch_inspection
+from agentflow.loader import load_pipeline_from_text
+from agentflow.prepared import ExecutionPaths, PreparedExecution, build_execution_paths
+from agentflow.runners.cloud_hypervisor import CloudHypervisorRunner
+from agentflow.runners.registry import RunnerRegistry
+from agentflow.specs import (
+    CloudHypervisorMount,
+    CloudHypervisorNetworkPolicy,
+    CloudHypervisorTarget,
+    NodeSpec,
+    PipelineSpec,
+)
+
+
+def _node(
+    target: dict[str, object],
+    *,
+    agent: str = "shell",
+    env: dict[str, str] | None = None,
+) -> NodeSpec:
+    return NodeSpec.model_validate(
+        {
+            "id": "vm-node",
+            "agent": agent,
+            "prompt": "run in a VM",
+            "env": env or {},
+            "target": target,
+        }
+    )
+
+
+def _paths(tmp_path: Path) -> ExecutionPaths:
+    return ExecutionPaths(
+        host_workdir=tmp_path / "workspace",
+        host_runtime_dir=tmp_path / "runtime",
+        target_workdir="/workspace",
+        target_runtime_dir="/agentflow-runtime",
+        app_root=tmp_path / "app",
+    )
+
+
+def _option_values(command: list[str], option: str) -> list[str]:
+    return [
+        command[index + 1]
+        for index, value in enumerate(command[:-1])
+        if value == option
+    ]
+
+
+def test_cloud_hypervisor_target_secure_defaults():
+    target = CloudHypervisorTarget(kernel="./vmlinux", rootfs="./rootfs")
+
+    assert target.cpus == 2
+    assert target.memory_mib == 4096
+    assert target.workdir_mount == "/workspace"
+    assert target.runtime_mount == "/agentflow-runtime"
+    assert target.app_mount is None
+    assert target.user == "host"
+    assert target.inherit_credentials is False
+    assert target.network_policy.mode == "none"
+    assert target.network_policy.num_queues == 2
+    assert target.seccomp == "true"
+
+
+@pytest.mark.parametrize(
+    ("shorthand", "expected"),
+    [
+        ("none", CloudHypervisorNetworkPolicy(mode="none")),
+        (
+            "tap",
+            CloudHypervisorNetworkPolicy(
+                mode="tap",
+                host_ip="192.168.249.1",
+                host_mask="255.255.255.0",
+                guest_address="192.168.249.2/24",
+                gateway="192.168.249.1",
+            ),
+        ),
+        (
+            "agenttap0",
+            CloudHypervisorNetworkPolicy(mode="tap", tap="agenttap0", dhcp=True),
+        ),
+    ],
+)
+def test_cloud_hypervisor_network_policy_shorthand(
+    shorthand: str,
+    expected: CloudHypervisorNetworkPolicy,
+):
+    assert CloudHypervisorNetworkPolicy.model_validate(shorthand) == expected
+
+
+@pytest.mark.parametrize(
+    ("patch", "message"),
+    [
+        ({"workdir_mount": "relative"}, r"workdir_mount.*absolute guest path"),
+        ({"runtime_mount": "//runtime"}, r"runtime_mount.*single leading slash"),
+        ({"runtime_mount": "/runtime:bad"}, r"runtime_mount.*colons"),
+        (
+            {"workdir_mount": "/", "runtime_mount": "/agentflow-runtime"},
+            r"reserved system path|must not overlap",
+        ),
+        ({"workdir_mount": "/proc/work"}, r"reserved system path.*proc"),
+        (
+            {"mounts": [{"source": ".", "target": "/dev/data"}]},
+            r"reserved system path.*dev",
+        ),
+        (
+            {
+                "mounts": [
+                    {"source": "one", "target": "/inputs"},
+                    {"source": "two", "target": "/inputs/nested"},
+                ]
+            },
+            r"mount targets must not overlap.*inputs/nested",
+        ),
+        (
+            {"mounts": [{"source": ".", "target": "/workspace/cache"}]},
+            r"mount targets must not overlap.*workspace",
+        ),
+        ({"user": "daemon"}, r"user.*host.*numeric"),
+        ({"user": "4294967295:1"}, r"user.*fit Linux 32-bit"),
+        ({"init_path": "sbin/init"}, r"init_path.*absolute guest path"),
+        (
+            {"nss_wrapper_path": "libnss_wrapper.so"},
+            r"nss_wrapper_path.*absolute guest path",
+        ),
+        ({"kernel_args": ["root=/dev/vda1"]}, r"kernel_args.*cannot override.*root"),
+        ({"kernel_args": ["rw"]}, r"kernel_args.*cannot override.*root"),
+        (
+            {"kernel_args": ["quiet init=/bin/sh"]},
+            r"kernel_args.*without whitespace",
+        ),
+        (
+            {"network_policy": {"mode": "none", "tap": "tap0"}},
+            r"network settings require.*tap",
+        ),
+        (
+            {
+                "network_policy": {
+                    "mode": "tap",
+                    "dhcp": True,
+                    "guest_address": "192.0.2.2/24",
+                }
+            },
+            r"dhcp.*guest_address.*mutually exclusive",
+        ),
+        (
+            {"network_policy": {"mode": "tap", "gateway": "192.0.2.1"}},
+            r"gateway.*requires.*guest_address",
+        ),
+        (
+            {"network_policy": {"mode": "tap", "host_ip": "192.0.2.1"}},
+            r"host_ip.*host_mask.*together",
+        ),
+        (
+            {
+                "network_policy": {
+                    "mode": "tap",
+                    "host_ip": "2001:db8::1",
+                    "host_mask": "255.255.255.0",
+                }
+            },
+            r"host_ip.*IPv4",
+        ),
+        (
+            {"network_policy": {"mode": "tap", "num_queues": 3}},
+            r"num_queues.*even",
+        ),
+    ],
+)
+def test_cloud_hypervisor_target_rejects_unsafe_or_conflicting_configuration(
+    patch: dict[str, object],
+    message: str,
+):
+    with pytest.raises(ValidationError, match=message):
+        _node(
+            {
+                "kind": "cloud_hypervisor",
+                "kernel": "vmlinux",
+                "rootfs": "rootfs",
+                **patch,
+            }
+        )
+
+
+def test_cloud_hypervisor_target_schema_parses_structured_mounts_and_network():
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": " vmlinux ",
+            "rootfs": " rootfs ",
+            "mounts": [
+                {"source": " ./fixtures ", "target": " /inputs ", "read_only": False}
+            ],
+            "network_policy": {
+                "mode": "tap",
+                "tap": "agenttap0",
+                "mac": "02:00:00:00:00:01",
+                "host_ip": "192.0.2.1",
+                "host_mask": "255.255.255.0",
+                "guest_address": "192.0.2.2/24",
+                "gateway": "192.0.2.1",
+                "dns": ["1.1.1.1"],
+            },
+        }
+    )
+
+    assert isinstance(node.target, CloudHypervisorTarget)
+    assert node.target.kernel == "vmlinux"
+    assert node.target.rootfs == "rootfs"
+    assert node.target.mounts == [
+        CloudHypervisorMount(source="./fixtures", target="/inputs", read_only=False)
+    ]
+    assert node.target.network_policy.tap == "agenttap0"
+    assert node.target.network_policy.guest_address == "192.0.2.2/24"
+
+
+def test_cloud_hypervisor_runner_plan_contains_vmm_vsock_and_virtiofs_configuration(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    for directory in (
+        paths.host_workdir,
+        paths.host_runtime_dir,
+        paths.app_root,
+        tmp_path / "rootfs",
+        tmp_path / "inputs",
+    ):
+        directory.mkdir(parents=True)
+    (tmp_path / "vmlinux").write_bytes(b"kernel")
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(tmp_path / "rootfs"),
+            "cpus": 4,
+            "memory_mib": 2048,
+            "app_mount": "/agentflow-app",
+            "mounts": [
+                {
+                    "source": str(tmp_path / "inputs"),
+                    "target": "/inputs",
+                    "read_only": True,
+                }
+            ],
+            "network_policy": {
+                "mode": "tap",
+                "tap": "agenttap0",
+                "host_ip": "192.0.2.1",
+                "host_mask": "255.255.255.0",
+                "guest_address": "192.0.2.2/24",
+                "gateway": "192.0.2.1",
+                "dns": ["1.1.1.1"],
+                "num_queues": 2,
+            },
+        },
+        env={"DATABASE_URL": "postgres://user:secret@example.invalid/db"},
+    )
+    prepared = PreparedExecution(
+        command=["bash", "-c", "echo ready"],
+        env=dict(node.env),
+        cwd="/workspace",
+        trace_kind="shell",
+        stdin="input\n",
+    )
+
+    plan = CloudHypervisorRunner().plan_execution(node, prepared, paths)
+
+    assert plan.kind == "cloud_hypervisor"
+    assert plan.command is not None
+    assert plan.command[0] == "cloud-hypervisor"
+    assert _option_values(plan.command, "--kernel") == [str(tmp_path / "vmlinux")]
+    assert _option_values(plan.command, "--cpus") == ["boot=4"]
+    assert _option_values(plan.command, "--memory") == ["size=2048M,shared=on"]
+    assert _option_values(plan.command, "--console") == ["off"]
+    assert "root=/dev/root" in _option_values(plan.command, "--cmdline")[0]
+    assert (
+        "init=/usr/local/bin/agentflow-cloud-hypervisor-init"
+        in _option_values(plan.command, "--cmdline")[0]
+    )
+    assert len(_option_values(plan.command, "--fs")) == 5
+    assert _option_values(plan.command, "--net") == [
+        "tap=agenttap0,ip=192.0.2.1,mask=255.255.255.0,num_queues=2"
+    ]
+    assert "postgres://" not in "\x00".join(plan.command)
+    assert plan.env == {}
+    assert plan.stdin is None
+    assert plan.payload is not None
+    assert plan.payload["env_keys"] == [
+        "DATABASE_URL",
+        "HOME",
+        "LD_PRELOAD",
+        "LOGNAME",
+        "NSS_WRAPPER_GROUP",
+        "NSS_WRAPPER_PASSWD",
+        "PYTHONPATH",
+        "USER",
+    ]
+    assert "secret" not in json.dumps(plan.payload)
+    assert plan.payload["guest_user"] == f"{os.getuid()}:{os.getgid()}"
+    assert plan.runtime_files == [".agentflow-nss/group", ".agentflow-nss/passwd"]
+
+    virtiofsd_commands = plan.payload["virtiofsd_commands"]
+    assert isinstance(virtiofsd_commands, list)
+    assert len(virtiofsd_commands) == 5
+    assert "--readonly" in virtiofsd_commands[0]
+    assert "--readonly" not in virtiofsd_commands[1]
+    assert "--readonly" not in virtiofsd_commands[2]
+    assert "--readonly" in virtiofsd_commands[3]
+    assert "--readonly" in virtiofsd_commands[4]
+    assert any(
+        argument.startswith("--translate-uid=map:")
+        for argument in virtiofsd_commands[0]
+    )
+
+
+def test_cloud_hypervisor_runner_rejects_writable_alias_of_read_only_workspace(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    paths.host_workdir.mkdir(parents=True)
+    paths.host_runtime_dir.mkdir()
+    (tmp_path / "rootfs").mkdir()
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(tmp_path / "rootfs"),
+            "workdir_read_only": True,
+            "mounts": [
+                {
+                    "source": str(paths.host_workdir / "."),
+                    "target": "/alias",
+                    "read_only": False,
+                }
+            ],
+        }
+    )
+    prepared = PreparedExecution(
+        command=["true"], env={}, cwd="/workspace", trace_kind="shell"
+    )
+
+    with pytest.raises(ValueError, match=r"read-write.*overlaps.*read-only.*workspace"):
+        CloudHypervisorRunner().plan_execution(node, prepared, paths)
+
+
+def test_cloud_hypervisor_runner_rejects_read_only_alias_of_writable_workspace(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    paths.host_workdir.mkdir(parents=True)
+    paths.host_runtime_dir.mkdir()
+    (tmp_path / "rootfs").mkdir()
+    fixtures = paths.host_workdir / "fixtures"
+    fixtures.mkdir()
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(tmp_path / "rootfs"),
+            "mounts": [
+                {
+                    "source": str(fixtures),
+                    "target": "/inputs",
+                    "read_only": True,
+                }
+            ],
+        }
+    )
+    prepared = PreparedExecution(
+        command=["true"], env={}, cwd="/workspace", trace_kind="shell"
+    )
+
+    with pytest.raises(ValueError, match=r"read-only.*overlaps.*writable.*workspace"):
+        CloudHypervisorRunner().plan_execution(node, prepared, paths)
+
+
+def test_cloud_hypervisor_runner_rejects_mixed_access_aliases_between_mounts(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    paths.host_workdir.mkdir(parents=True)
+    paths.host_runtime_dir.mkdir()
+    (tmp_path / "rootfs").mkdir()
+    shared = tmp_path / "shared"
+    (shared / "nested").mkdir(parents=True)
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(tmp_path / "rootfs"),
+            "mounts": [
+                {"source": str(shared), "target": "/inputs", "read_only": True},
+                {
+                    "source": str(shared / "nested"),
+                    "target": "/outputs",
+                    "read_only": False,
+                },
+            ],
+        }
+    )
+    prepared = PreparedExecution(
+        command=["true"], env={}, cwd="/workspace", trace_kind="shell"
+    )
+
+    with pytest.raises(ValueError, match=r"read-only and read-write.*must not overlap"):
+        CloudHypervisorRunner().plan_execution(node, prepared, paths)
+
+
+def test_cloud_hypervisor_runner_protects_rootfs_from_writable_workspace_alias(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    rootfs = paths.host_workdir / ".agentflow" / "cloud-hypervisor" / "rootfs"
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(rootfs),
+        }
+    )
+    prepared = PreparedExecution(
+        command=["true"], env={}, cwd="/workspace", trace_kind="shell"
+    )
+
+    with pytest.raises(ValueError, match=r"writable managed workspace.*rootfs"):
+        CloudHypervisorRunner().plan_execution(node, prepared, paths)
+
+    read_only_node = node.model_copy(
+        update={"target": node.target.model_copy(update={"workdir_read_only": True})}
+    )
+    plan = CloudHypervisorRunner().plan_execution(read_only_node, prepared, paths)
+    assert plan.kind == "cloud_hypervisor"
+
+
+def test_cloud_hypervisor_runner_requires_explicit_credential_inheritance(
+    tmp_path: Path,
+):
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(tmp_path / "rootfs"),
+        }
+    )
+    prepared = PreparedExecution(
+        command=["codex", "exec", "hi"],
+        env={},
+        cwd="/workspace",
+        trace_kind="codex",
+        runtime_symlinks={"codex_home/auth.json": str(tmp_path / "auth.json")},
+    )
+
+    with pytest.raises(
+        ValueError, match=r"do not expose.*credentials.*inherit_credentials"
+    ):
+        CloudHypervisorRunner().plan_execution(node, prepared, _paths(tmp_path))
+
+
+def test_cloud_hypervisor_runtime_copies_inherited_credentials_privately(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    paths.host_workdir.mkdir(parents=True)
+    paths.host_runtime_dir.mkdir()
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"token":"secret"}', encoding="utf-8")
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": "vmlinux",
+            "rootfs": "rootfs",
+            "inherit_credentials": True,
+        }
+    )
+    prepared = PreparedExecution(
+        command=["true"],
+        env={},
+        cwd="/workspace",
+        trace_kind="codex",
+        runtime_files={"config/settings.json": "{}"},
+        runtime_symlinks={"codex_home/auth.json": str(auth)},
+    )
+    runner = CloudHypervisorRunner()
+
+    runner._prepare_runtime(node.target, prepared, paths)
+
+    credential = paths.host_runtime_dir / "codex_home" / "auth.json"
+    generated = paths.host_runtime_dir / "config" / "settings.json"
+    assert credential.read_text(encoding="utf-8") == '{"token":"secret"}'
+    assert credential.stat().st_mode & 0o777 == 0o600
+    assert generated.stat().st_mode & 0o777 == 0o600
+    assert paths.host_runtime_dir.stat().st_mode & 0o777 == 0o700
+    assert not credential.is_symlink()
+
+
+def test_cloud_hypervisor_console_log_replaces_guest_symlink_without_following(
+    tmp_path: Path,
+):
+    paths = _paths(tmp_path)
+    paths.host_runtime_dir.mkdir(parents=True)
+    runner = CloudHypervisorRunner()
+    state_dir = runner._state_dir(paths)
+    state_dir.mkdir(mode=0o700)
+    (state_dir / "console.log").write_text("guest console\n", encoding="utf-8")
+    victim = tmp_path / "victim.txt"
+    victim.write_text("keep me\n", encoding="utf-8")
+    destination = paths.host_runtime_dir / "cloud-hypervisor-console.log"
+    destination.symlink_to(victim)
+
+    try:
+        runner._copy_console_log(paths)
+    finally:
+        runner._cleanup_state_dir(paths)
+
+    assert victim.read_text(encoding="utf-8") == "keep me\n"
+    assert destination.read_text(encoding="utf-8") == "guest console\n"
+    assert not destination.is_symlink()
+    assert destination.stat().st_mode & 0o777 == 0o600
+
+
+def test_cloud_hypervisor_loader_resolves_kernel_rootfs_and_mount_sources(
+    tmp_path: Path,
+):
+    pipeline = load_pipeline_from_text(
+        json.dumps(
+            {
+                "name": "cloud-hypervisor-loader",
+                "working_dir": "repo",
+                "nodes": [
+                    {
+                        "id": "vm",
+                        "agent": "shell",
+                        "prompt": "true",
+                        "target": {
+                            "kind": "cloud_hypervisor",
+                            "kernel": "assets/vmlinux",
+                            "rootfs": "assets/rootfs",
+                            "mounts": [{"source": "fixtures", "target": "/inputs"}],
+                        },
+                    }
+                ],
+            }
+        ),
+        base_dir=tmp_path,
+    )
+
+    target = pipeline.nodes[0].target
+    assert isinstance(target, CloudHypervisorTarget)
+    assert target.kernel == str((tmp_path / "repo" / "assets" / "vmlinux").resolve())
+    assert target.rootfs == str((tmp_path / "repo" / "assets" / "rootfs").resolve())
+    assert target.mounts[0].source == str((tmp_path / "repo" / "fixtures").resolve())
+
+
+def test_cloud_hypervisor_execution_paths_use_guest_mounts(tmp_path: Path):
+    target = CloudHypervisorTarget(
+        kernel="vmlinux",
+        rootfs="rootfs",
+        workdir_mount="/repo",
+        runtime_mount="/runtime-alt",
+    )
+
+    paths = build_execution_paths(
+        base_dir=tmp_path / "runs",
+        pipeline_workdir=tmp_path / "workspace",
+        run_id="run-1",
+        node_id="vm",
+        node_target=target,
+    )
+
+    assert paths.host_workdir == tmp_path / "workspace"
+    assert paths.target_workdir == "/repo"
+    assert paths.target_runtime_dir == "/runtime-alt"
+
+
+def test_cloud_hypervisor_runner_is_registered():
+    assert isinstance(RunnerRegistry().get("cloud_hypervisor"), CloudHypervisorRunner)
+
+
+def test_cloud_hypervisor_execute_reports_launch_validation_failure(
+    tmp_path: Path, monkeypatch
+):
+    runner = CloudHypervisorRunner()
+
+    def fail_validation(_target, _paths, _shares) -> None:
+        raise FileNotFoundError("missing test kernel")
+
+    monkeypatch.setattr(runner, "_validate_execution_host", fail_validation)
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": str(tmp_path / "vmlinux"),
+            "rootfs": str(tmp_path / "rootfs"),
+        }
+    )
+    prepared = PreparedExecution(
+        command=["true"], env={}, cwd="/workspace", trace_kind="shell"
+    )
+    output: list[tuple[str, str]] = []
+
+    async def on_output(stream: str, line: str) -> None:
+        output.append((stream, line))
+
+    result = asyncio.run(
+        runner.execute(node, prepared, _paths(tmp_path), on_output, lambda: False)
+    )
+
+    assert result.exit_code == 1
+    assert result.stderr_lines == [
+        "Cloud Hypervisor launch validation failed: missing test kernel"
+    ]
+    assert output == [("stderr", result.stderr_lines[0])]
+
+
+def test_cloud_hypervisor_runner_handles_hybrid_vsock_acknowledgement(
+    tmp_path: Path, monkeypatch
+):
+    runner = CloudHypervisorRunner()
+    paths = _paths(tmp_path)
+    state_dir = Path(tempfile.mkdtemp(prefix="agentflow-ch-test-"))
+    monkeypatch.setattr(runner, "_state_dir", lambda paths: state_dir)
+    target = CloudHypervisorTarget(kernel="vmlinux", rootfs="rootfs")
+    received: list[bytes] = []
+
+    class FakeVmm:
+        returncode = None
+
+    async def scenario() -> None:
+        async def handle(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            received.append(await reader.readline())
+            writer.write(b"OK 1073741824\n")
+            writer.write(b'{"event":"hello","protocol":1}\n')
+            await writer.drain()
+            await reader.read()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle, path=state_dir / "vsock.sock")
+        try:
+            loop = asyncio.get_running_loop()
+            _, writer = await runner._connect_guest(
+                target,
+                paths,
+                FakeVmm(),
+                lambda: False,
+                loop.time() + 5,
+            )
+            writer.close()
+            await writer.wait_closed()
+            await asyncio.sleep(0)
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        shutil.rmtree(state_dir)
+
+    assert received == [b"CONNECT 4050\n"]
+
+
+def test_cloud_hypervisor_runner_reassembles_fragmented_guest_lines(
+    tmp_path: Path,
+):
+    runner = CloudHypervisorRunner()
+    guest_events = (
+        {"event": "started", "pid": 42},
+        {
+            "event": "stream",
+            "stream": "stdout",
+            "text": "first ",
+            "line_end": False,
+        },
+        {
+            "event": "stream",
+            "stream": "stdout",
+            "text": "line",
+            "line_end": True,
+        },
+        {"event": "result", "exit_code": 0},
+    )
+
+    class FakeWriter:
+        def __init__(self) -> None:
+            self.data = b""
+
+        def write(self, data: bytes) -> None:
+            self.data += data
+
+        async def drain(self) -> None:
+            return None
+
+    writer = FakeWriter()
+    streamed: list[tuple[str, str]] = []
+
+    async def scenario():
+        reader = asyncio.StreamReader()
+        for event in guest_events:
+            reader.feed_data(json.dumps(event).encode("utf-8") + b"\n")
+        reader.feed_eof()
+
+        async def on_output(stream: str, line: str) -> None:
+            streamed.append((stream, line))
+
+        return await runner._consume_guest(
+            reader,
+            writer,
+            {"protocol": 1},
+            on_output,
+            lambda: False,
+            asyncio.get_running_loop().time() + 5,
+        )
+
+    result = asyncio.run(scenario())
+
+    assert result.exit_code == 0
+    assert result.stdout_lines == ["first line"]
+    assert streamed == [("stdout", "first line")]
+    assert writer.data == b'{"protocol":1}\n'
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"event": "stream", "stream": "invalid", "text": "value"},
+        {"event": "started", "pid": True},
+        {"event": "started", "pid": 0},
+        {"event": "result", "exit_code": True},
+    ],
+)
+def test_cloud_hypervisor_runner_rejects_malformed_guest_events(
+    event: dict[str, object],
+):
+    runner = CloudHypervisorRunner()
+
+    class FakeWriter:
+        def write(self, data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+    streamed: list[tuple[str, str]] = []
+
+    async def scenario():
+        reader = asyncio.StreamReader()
+        reader.feed_data(json.dumps(event).encode("utf-8") + b"\n")
+        reader.feed_eof()
+
+        async def on_output(stream: str, line: str) -> None:
+            streamed.append((stream, line))
+
+        return await runner._consume_guest(
+            reader,
+            FakeWriter(),
+            {"protocol": 1},
+            on_output,
+            lambda: False,
+            asyncio.get_running_loop().time() + 5,
+        )
+
+    result = asyncio.run(scenario())
+
+    assert result.exit_code == 1
+    assert len(result.stderr_lines) == 1
+    assert streamed == [("stderr", result.stderr_lines[0])]
+
+
+def test_codex_cloud_hypervisor_credentials_are_opt_in(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    codex_home = home / ".codex"
+    codex_home.mkdir(parents=True)
+    (codex_home / "config.toml").write_text("model = 'gpt-5'\n", encoding="utf-8")
+    (codex_home / "auth.json").write_text('{"token":"secret"}', encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    paths = _paths(tmp_path)
+
+    isolated = _node(
+        {"kind": "cloud_hypervisor", "kernel": "vmlinux", "rootfs": "rootfs"},
+        agent="codex",
+    )
+    inherited = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": "vmlinux",
+            "rootfs": "rootfs",
+            "inherit_credentials": True,
+        },
+        agent="codex",
+    )
+
+    isolated_prepared = CodexAdapter().prepare(isolated, "hi", paths)
+    inherited_prepared = CodexAdapter().prepare(inherited, "hi", paths)
+
+    assert isolated_prepared.runtime_symlinks == {}
+    assert "CODEX_HOME" not in isolated_prepared.env
+    assert inherited_prepared.runtime_symlinks == {
+        "codex_home/config.toml": str(codex_home / "config.toml"),
+        "codex_home/auth.json": str(codex_home / "auth.json"),
+    }
+    assert inherited_prepared.env["CODEX_HOME"] == "/agentflow-runtime/codex_home"
+
+
+def test_cloud_hypervisor_inspection_redacts_env_and_warns_for_tap_and_credentials(
+    tmp_path: Path,
+):
+    pipeline = PipelineSpec.model_validate(
+        {
+            "name": "inspect-cloud-hypervisor",
+            "working_dir": str(tmp_path),
+            "nodes": [
+                {
+                    "id": "vm",
+                    "agent": "shell",
+                    "prompt": "echo hi",
+                    "env": {"DATABASE_URL": "postgres://secret"},
+                    "target": {
+                        "kind": "cloud_hypervisor",
+                        "kernel": str(tmp_path / "vmlinux"),
+                        "rootfs": str(tmp_path / "rootfs"),
+                        "workdir_read_only": True,
+                        "inherit_credentials": True,
+                        "network_policy": "tap",
+                        "seccomp": "false",
+                    },
+                }
+            ],
+        }
+    )
+
+    report = build_launch_inspection(pipeline, runs_dir=str(tmp_path / "runs"))
+    node = report["nodes"][0]
+
+    assert node["launch"]["kind"] == "cloud_hypervisor"
+    assert node["prepared"]["env"] == {"DATABASE_URL": "<redacted>"}
+    assert "postgres://secret" not in json.dumps(node)
+    assert any("credential inheritance" in warning for warning in node["warnings"])
+    assert any("TAP networking" in warning for warning in node["warnings"])
+    assert any(
+        "seccomp filtering is disabled" in warning for warning in node["warnings"]
+    )
+
+
+def test_guest_request_validation_rejects_system_and_overlapping_mounts():
+    base = {
+        "protocol": 1,
+        "command": ["true"],
+        "env": {},
+        "cwd": "/workspace",
+        "stdin": None,
+        "uid": 0,
+        "gid": 0,
+        "network": {"mode": "none"},
+    }
+    with pytest.raises(GuestRequestError, match="reserved guest path"):
+        _validate_request(
+            {
+                **base,
+                "mounts": [
+                    {"tag": "agentflow-bad", "target": "/proc/data", "read_only": True}
+                ],
+            }
+        )
+    with pytest.raises(GuestRequestError, match="overlaps another"):
+        _validate_mounts(
+            [
+                {"tag": "agentflow-one", "target": "/inputs", "read_only": True},
+                {"tag": "agentflow-two", "target": "/inputs/nested", "read_only": True},
+            ]
+        )
+
+
+def test_guest_dhcp_installs_dns_through_writable_runtime_files(
+    tmp_path: Path, monkeypatch
+):
+    resolv_conf = tmp_path / "agentflow-resolv.conf"
+    dhcp_config = tmp_path / "agentflow-udhcpc.conf"
+    commands: list[tuple[list[str], str]] = []
+
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._RUNTIME_RESOLV_CONF", resolv_conf
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._RUNTIME_DHCP_CONFIG", dhcp_config
+    )
+
+    def run_checked(command: list[str], *, description: str) -> None:
+        commands.append((command, description))
+        if command[0] == "udhcpc":
+            resolv_conf.write_text("nameserver 192.0.2.1\n", encoding="utf-8")
+
+    monkeypatch.setattr("agentflow.cloud_hypervisor_guest._run_checked", run_checked)
+
+    assert _configure_dhcp() is True
+    assert dhcp_config.read_text(encoding="utf-8") == (f'RESOLV_CONF="{resolv_conf}"\n')
+    assert commands == [
+        (
+            [
+                "mount",
+                "--bind",
+                str(dhcp_config),
+                "/etc/udhcpc/udhcpc.conf",
+            ],
+            "installing read-only-rootfs DHCP config",
+        ),
+        (["udhcpc", "-q", "-n", "-i", "eth0"], "guest DHCP configuration"),
+        (
+            ["mount", "--bind", str(resolv_conf), "/etc/resolv.conf"],
+            "installing guest DNS config",
+        ),
+    ]
+
+
+def test_guest_explicit_dns_replaces_dhcp_nameservers_without_rebinding(
+    tmp_path: Path, monkeypatch
+):
+    resolv_conf = tmp_path / "agentflow-resolv.conf"
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._RUNTIME_RESOLV_CONF", resolv_conf
+    )
+
+    def configure_dhcp() -> bool:
+        resolv_conf.write_text("nameserver 192.0.2.1\n", encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._configure_dhcp", configure_dhcp
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._run_checked",
+        lambda command, *, description: commands.append(command),
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest.subprocess.run",
+        lambda *args, **kwargs: None,
+    )
+
+    _configure_network({"mode": "tap", "dhcp": True, "dns": ["1.1.1.1", "9.9.9.9"]})
+
+    assert resolv_conf.read_text(encoding="utf-8") == (
+        "nameserver 1.1.1.1\nnameserver 9.9.9.9\n"
+    )
+    assert commands == [["ip", "link", "set", "eth0", "up"]]
+
+
+def test_guest_privilege_drop_uses_absolute_launcher_with_empty_environment():
+    command, launcher_env = _command_for_identity(
+        ["tool=with-equals", "argument"],
+        {
+            "PATH": "/workspace/untrusted",
+            "LD_PRELOAD": "/workspace/untrusted.so",
+            "TOKEN": "secret",
+        },
+        1000,
+        1000,
+    )
+
+    assert command[:6] == [
+        "/sbin/su-exec",
+        "1000:1000",
+        "/usr/bin/env",
+        "-i",
+        "--",
+        "PATH=/workspace/untrusted",
+    ]
+    assert "LD_PRELOAD=/workspace/untrusted.so" in command
+    assert command[-6:] == [
+        "/bin/sh",
+        "-c",
+        'exec -- "$@"',
+        "agentflow-command",
+        "tool=with-equals",
+        "argument",
+    ]
+    assert launcher_env == {}
+
+
+def test_guest_agent_executes_and_multiplexes_stdout_stderr(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._mount_shares", lambda mounts: None
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._configure_network", lambda network: None
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    request = {
+        "command": [
+            sys.executable,
+            "-c",
+            "import sys; data=sys.stdin.read(); print('out:'+data.strip()); print('err-line', file=sys.stderr)",
+        ],
+        "env": {"HOME": str(home)},
+        "cwd": str(tmp_path),
+        "stdin": "payload\n",
+        "uid": 0,
+        "gid": 0,
+        "mounts": [],
+        "network": {"mode": "none"},
+    }
+    stream = io.BytesIO()
+
+    exit_code = _execute_request(request, stream)
+    events = [json.loads(line) for line in stream.getvalue().splitlines()]
+
+    assert exit_code == 0
+    assert events[0]["event"] == "started"
+    assert {
+        event.get("text") for event in events if event.get("event") == "stream"
+    } == {
+        "out:payload",
+        "err-line",
+    }
+
+
+def test_guest_agent_chunks_large_unbroken_output_below_protocol_reader_limit(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._mount_shares", lambda mounts: None
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._configure_network", lambda network: None
+    )
+    request = {
+        "command": [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write(b'\\0' * 20000)",
+        ],
+        "env": {"HOME": str(tmp_path)},
+        "cwd": str(tmp_path),
+        "stdin": None,
+        "uid": 0,
+        "gid": 0,
+        "mounts": [],
+        "network": {"mode": "none"},
+    }
+    stream = io.BytesIO()
+
+    assert _execute_request(request, stream) == 0
+
+    encoded_events = stream.getvalue().splitlines()
+    assert max(map(len, encoded_events)) < 64 * 1024
+    events = [json.loads(line) for line in encoded_events]
+    stream_events = [event for event in events if event.get("event") == "stream"]
+    assert any(event["line_end"] is False for event in stream_events)
+    assert stream_events[-1]["line_end"] is True
+    stdout = "".join(
+        event["text"]
+        for event in events
+        if event.get("event") == "stream" and event.get("stream") == "stdout"
+    )
+    assert stdout == "\0" * 20000
+
+
+def test_guest_agent_preserves_utf8_across_large_output_chunks(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._mount_shares", lambda mounts: None
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._configure_network", lambda network: None
+    )
+    expected = "a" * 8191 + "é" + "tail"
+    request = {
+        "command": [
+            sys.executable,
+            "-c",
+            f"import sys; sys.stdout.buffer.write({expected.encode()!r})",
+        ],
+        "env": {"HOME": str(tmp_path)},
+        "cwd": str(tmp_path),
+        "stdin": None,
+        "uid": 0,
+        "gid": 0,
+        "mounts": [],
+        "network": {"mode": "none"},
+    }
+    stream = io.BytesIO()
+
+    assert _execute_request(request, stream) == 0
+
+    events = [json.loads(line) for line in stream.getvalue().splitlines()]
+    stdout = "".join(
+        event["text"]
+        for event in events
+        if event.get("event") == "stream" and event.get("stream") == "stdout"
+    )
+    assert stdout == expected
+
+
+def test_guest_agent_does_not_wait_for_child_inheriting_output_pipes(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._mount_shares", lambda mounts: None
+    )
+    monkeypatch.setattr(
+        "agentflow.cloud_hypervisor_guest._configure_network", lambda network: None
+    )
+    monkeypatch.setattr("agentflow.cloud_hypervisor_guest._STREAM_DRAIN_SECONDS", 0.05)
+    request = {
+        "command": [
+            sys.executable,
+            "-c",
+            (
+                "import subprocess, sys; "
+                "child=subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)']); "
+                "print(child.pid, flush=True)"
+            ),
+        ],
+        "env": {"HOME": str(tmp_path)},
+        "cwd": str(tmp_path),
+        "stdin": None,
+        "uid": 0,
+        "gid": 0,
+        "mounts": [],
+        "network": {"mode": "none"},
+    }
+    stream = io.BytesIO()
+    started = time.monotonic()
+    assert _execute_request(request, stream) == 0
+    elapsed = time.monotonic() - started
+
+    events = [json.loads(line) for line in stream.getvalue().splitlines()]
+    child_pid = int(
+        next(
+            event["text"]
+            for event in events
+            if event.get("event") == "stream" and event.get("stream") == "stdout"
+        )
+    )
+    try:
+        os.kill(child_pid, 9)
+    except ProcessLookupError:
+        pass
+
+    assert elapsed < 1.0
+
+
+def test_cloud_hypervisor_live_kvm_smoke(tmp_path: Path):
+    if os.environ.get("AGENTFLOW_CH_LIVE_TEST") != "1":
+        pytest.skip("set AGENTFLOW_CH_LIVE_TEST=1 with kernel and rootfs paths")
+
+    kernel = os.environ["AGENTFLOW_CH_KERNEL"]
+    rootfs = os.environ["AGENTFLOW_CH_ROOTFS"]
+    workspace = tmp_path / "workspace"
+    runtime = tmp_path / "runtime"
+    inputs = tmp_path / "inputs"
+    outputs = tmp_path / "outputs"
+    app = tmp_path / "app"
+    for directory in (workspace, runtime, inputs, outputs, app):
+        directory.mkdir()
+    (inputs / "value.txt").write_text("mounted input\n", encoding="utf-8")
+    fake_launcher = workspace / "su-exec"
+    fake_launcher.write_text(
+        '#!/bin/sh\ntouch /workspace/fake-su-exec-used\nexec /sbin/su-exec "$@"\n',
+        encoding="utf-8",
+    )
+    fake_launcher.chmod(0o755)
+    paths = ExecutionPaths(
+        host_workdir=workspace,
+        host_runtime_dir=runtime,
+        target_workdir="/workspace",
+        target_runtime_dir="/agentflow-runtime",
+        app_root=app,
+    )
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": kernel,
+            "rootfs": rootfs,
+            "binary": os.environ.get("AGENTFLOW_CH_BINARY", "cloud-hypervisor"),
+            "virtiofsd": os.environ.get("AGENTFLOW_CH_VIRTIOFSD", "virtiofsd"),
+            "cpus": 1,
+            "memory_mib": 512,
+            "mounts": [
+                {"source": str(inputs), "target": "/inputs", "read_only": True},
+                {"source": str(outputs), "target": "/outputs", "read_only": False},
+            ],
+        },
+        env={
+            "PROBE": "forwarded",
+            "PATH": "/workspace:/opt/agentflow-venv/bin:/usr/local/bin:/usr/bin:/bin",
+        },
+    )
+    prepared = PreparedExecution(
+        command=[
+            "python3",
+            "-c",
+            (
+                "import os, pathlib, pwd, sys; "
+                "data=sys.stdin.read().strip(); "
+                "pathlib.Path('vm-owned.txt').write_text(data); "
+                "pathlib.Path('/outputs/result.txt').write_text("
+                "pathlib.Path('/inputs/value.txt').read_text()); "
+                "print(f'{pwd.getpwuid(os.getuid()).pw_name}:{os.getuid()}:{os.getgid()}:{os.environ[\"PROBE\"]}:{data}'); "
+                "print('a' * 8191 + 'é' + 'tail', end=''); "
+                "print('guest-stderr', file=sys.stderr)"
+            ),
+        ],
+        env={
+            "PROBE": "forwarded",
+            "PATH": "/workspace:/opt/agentflow-venv/bin:/usr/local/bin:/usr/bin:/bin",
+        },
+        cwd="/workspace",
+        trace_kind="shell",
+        stdin="stdin payload\n",
+    )
+    streamed: dict[str, list[str]] = {"stdout": [], "stderr": []}
+
+    async def on_output(stream: str, line: str) -> None:
+        streamed[stream].append(line)
+
+    result = asyncio.run(
+        CloudHypervisorRunner().execute(node, prepared, paths, on_output, lambda: False)
+    )
+
+    assert result.exit_code == 0
+    assert result.timed_out is False
+    assert result.cancelled is False
+    assert any(
+        line.endswith(":forwarded:stdin payload") for line in result.stdout_lines
+    )
+    assert "a" * 8191 + "é" + "tail" in result.stdout_lines
+    assert "guest-stderr" in result.stderr_lines
+    assert streamed["stdout"] == result.stdout_lines
+    assert streamed["stderr"] == result.stderr_lines
+    assert (workspace / "vm-owned.txt").read_text(encoding="utf-8") == "stdin payload"
+    assert (outputs / "result.txt").read_text(encoding="utf-8") == "mounted input\n"
+    assert not (workspace / "fake-su-exec-used").exists()
+    if hasattr(os, "getuid"):
+        assert (workspace / "vm-owned.txt").stat().st_uid == os.getuid()
+        assert (outputs / "result.txt").stat().st_uid == os.getuid()
+
+
+def test_cloud_hypervisor_live_cancellation_cleans_processes_and_state(
+    tmp_path: Path,
+):
+    if os.environ.get("AGENTFLOW_CH_LIVE_TEST") != "1":
+        pytest.skip("set AGENTFLOW_CH_LIVE_TEST=1 with kernel and rootfs paths")
+
+    workspace = tmp_path / "workspace"
+    runtime = tmp_path / "runtime"
+    app = tmp_path / "app"
+    for directory in (workspace, runtime, app):
+        directory.mkdir()
+    paths = ExecutionPaths(
+        host_workdir=workspace,
+        host_runtime_dir=runtime,
+        target_workdir="/workspace",
+        target_runtime_dir="/agentflow-runtime",
+        app_root=app,
+    )
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": os.environ["AGENTFLOW_CH_KERNEL"],
+            "rootfs": os.environ["AGENTFLOW_CH_ROOTFS"],
+            "binary": os.environ.get("AGENTFLOW_CH_BINARY", "cloud-hypervisor"),
+            "virtiofsd": os.environ.get("AGENTFLOW_CH_VIRTIOFSD", "virtiofsd"),
+            "cpus": 1,
+            "memory_mib": 512,
+        }
+    )
+    prepared = PreparedExecution(
+        command=["sh", "-c", "printf 'command-started\\n'; sleep 30"],
+        env={},
+        cwd="/workspace",
+        trace_kind="shell",
+    )
+    cancel_requested = False
+
+    async def on_output(stream: str, line: str) -> None:
+        nonlocal cancel_requested
+        if stream == "stdout" and line == "command-started":
+            cancel_requested = True
+
+    runner = CloudHypervisorRunner()
+    result = asyncio.run(
+        runner.execute(node, prepared, paths, on_output, lambda: cancel_requested)
+    )
+
+    assert result.exit_code == 130
+    assert result.cancelled is True
+    assert not runner._state_dir(paths).exists()
+
+
+def test_cloud_hypervisor_live_precreated_tap_connectivity(tmp_path: Path):
+    tap = os.environ.get("AGENTFLOW_CH_LIVE_TAP")
+    if os.environ.get("AGENTFLOW_CH_LIVE_TEST") != "1" or not tap:
+        pytest.skip("set AGENTFLOW_CH_LIVE_TEST=1 and AGENTFLOW_CH_LIVE_TAP")
+
+    workspace = tmp_path / "workspace"
+    runtime = tmp_path / "runtime"
+    app = tmp_path / "app"
+    for directory in (workspace, runtime, app):
+        directory.mkdir()
+    paths = ExecutionPaths(
+        host_workdir=workspace,
+        host_runtime_dir=runtime,
+        target_workdir="/workspace",
+        target_runtime_dir="/agentflow-runtime",
+        app_root=app,
+    )
+    host_address = os.environ.get("AGENTFLOW_CH_LIVE_TAP_HOST", "192.0.2.1")
+    guest_address = os.environ.get("AGENTFLOW_CH_LIVE_TAP_GUEST", "192.0.2.2/30")
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": os.environ["AGENTFLOW_CH_KERNEL"],
+            "rootfs": os.environ["AGENTFLOW_CH_ROOTFS"],
+            "binary": os.environ.get("AGENTFLOW_CH_BINARY", "cloud-hypervisor"),
+            "virtiofsd": os.environ.get("AGENTFLOW_CH_VIRTIOFSD", "virtiofsd"),
+            "cpus": 1,
+            "memory_mib": 512,
+            "user": "root",
+            "network_policy": {
+                "mode": "tap",
+                "tap": tap,
+                "guest_address": guest_address,
+                "num_queues": 2,
+            },
+        }
+    )
+    prepared = PreparedExecution(
+        command=["ping", "-c", "1", "-W", "2", host_address],
+        env={},
+        cwd="/workspace",
+        trace_kind="shell",
+    )
+
+    async def on_output(stream: str, line: str) -> None:
+        return None
+
+    result = asyncio.run(
+        CloudHypervisorRunner().execute(node, prepared, paths, on_output, lambda: False)
+    )
+
+    assert result.exit_code == 0, result.stderr_lines
+    assert any(host_address in line for line in result.stdout_lines)
+
+
+def test_cloud_hypervisor_live_precreated_tap_dhcp_and_dns(tmp_path: Path):
+    tap = os.environ.get("AGENTFLOW_CH_LIVE_DHCP_TAP")
+    if os.environ.get("AGENTFLOW_CH_LIVE_TEST") != "1" or not tap:
+        pytest.skip("set AGENTFLOW_CH_LIVE_TEST=1 and AGENTFLOW_CH_LIVE_DHCP_TAP")
+
+    workspace = tmp_path / "workspace"
+    runtime = tmp_path / "runtime"
+    app = tmp_path / "app"
+    for directory in (workspace, runtime, app):
+        directory.mkdir()
+    paths = ExecutionPaths(
+        host_workdir=workspace,
+        host_runtime_dir=runtime,
+        target_workdir="/workspace",
+        target_runtime_dir="/agentflow-runtime",
+        app_root=app,
+    )
+    host_address = os.environ.get("AGENTFLOW_CH_LIVE_DHCP_HOST", "192.0.2.1")
+    guest_prefix = os.environ.get("AGENTFLOW_CH_LIVE_DHCP_GUEST_PREFIX", "192.0.2.")
+    dns_address = os.environ.get("AGENTFLOW_CH_LIVE_DHCP_DNS", host_address)
+    node = _node(
+        {
+            "kind": "cloud_hypervisor",
+            "kernel": os.environ["AGENTFLOW_CH_KERNEL"],
+            "rootfs": os.environ["AGENTFLOW_CH_ROOTFS"],
+            "binary": os.environ.get("AGENTFLOW_CH_BINARY", "cloud-hypervisor"),
+            "virtiofsd": os.environ.get("AGENTFLOW_CH_VIRTIOFSD", "virtiofsd"),
+            "cpus": 1,
+            "memory_mib": 512,
+            "user": "root",
+            "network_policy": tap,
+        }
+    )
+    prepared = PreparedExecution(
+        command=[
+            "sh",
+            "-c",
+            'ip -4 -o address show dev eth0; cat /etc/resolv.conf; ping -c 1 -W 2 "$1"',
+            "agentflow-dhcp-probe",
+            host_address,
+        ],
+        env={},
+        cwd="/workspace",
+        trace_kind="shell",
+    )
+
+    async def on_output(stream: str, line: str) -> None:
+        return None
+
+    result = asyncio.run(
+        CloudHypervisorRunner().execute(node, prepared, paths, on_output, lambda: False)
+    )
+
+    assert result.exit_code == 0, result.stderr_lines
+    assert any(guest_prefix in line for line in result.stdout_lines)
+    assert f"nameserver {dns_address}" in result.stdout_lines
+    assert any(host_address in line for line in result.stdout_lines)


### PR DESCRIPTION
## Summary

- add a structured `cloud_hypervisor` target that boots one ephemeral direct-kernel KVM VM per node
- use a read-only virtio-fs rootfs plus separately controlled workspace, runtime, app, and additional directory shares
- carry commands, explicit environment values, stdin, streaming stdout/stderr, and exit status over hybrid vsock without SSH
- support isolated networking by default and explicit static or DHCP-backed TAP policies
- preserve host UID/GID ownership, generate private NSS state, and drop privileges through a trusted absolute launcher
- make host credential inheritance opt-in and redact isolated guest environments in launch inspection
- add the guest PID 1 agent, all-agent rootfs exporter, documentation, example, and comprehensive unit/live tests

## Security and lifecycle

- rootfs and read-only shares are enforced by both virtiofsd and guest mount flags
- canonical host-path and guest-target checks reject writable/read-only aliasing and mount shadowing
- runtime files, copied credentials, and logs use private permissions
- prepared environment values are sent only in the in-memory vsock request, not VMM or virtiofsd argv
- success, failure, cancellation, and timeout paths stop Cloud Hypervisor and all virtiofsd processes and remove private sockets
- TAP attachment remains host-managed; NAT, firewalling, and destination policy are deliberately not implied by target configuration

## Validation

- `242 passed, 4 skipped` across Cloud Hypervisor, Docker, inspection, runner, loader, prepared execution, validation, and adapter regression suites
- `58 passed` on a Linux `/dev/kvm` host with real Cloud Hypervisor and Rust virtiofsd, including static TAP, DHCP/DNS on a read-only rootfs, cancellation cleanup, host ownership, malicious launcher environment, stdin, and long UTF-8 output
- credential-free example completed in a real VM and found AgentFlow, Codex, Claude, Kimi, Pi, and Docker
- full repository suite: `838 passed, 4 skipped, 53 failed`; the 53 failures match the pre-existing macOS TTY/Kimi-shell/preflight and orchestrator timing baseline, with no new failures
- Ruff on new files, Python compilation, ShellCheck, `sh -n`, and `git diff --check` pass